### PR TITLE
[#10]feat: Docker로 MariaDB 연동 및 user_post 테이블 엔티티 구현

### DIFF
--- a/src/main/java/foiegras/ygyg/YgygApplication.java
+++ b/src/main/java/foiegras/ygyg/YgygApplication.java
@@ -3,9 +3,11 @@ package foiegras.ygyg;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 
 @SpringBootApplication
+@EnableJpaAuditing // createdAt, postedAt 자동화 위해 붙인 어노테이션
 public class YgygApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/foiegras/ygyg/post/infrastructure/entity/UserPostEntity.java
+++ b/src/main/java/foiegras/ygyg/post/infrastructure/entity/UserPostEntity.java
@@ -1,4 +1,53 @@
 package foiegras.ygyg.post.infrastructure.entity;
 
-public class UserPostEntity {
+
+import foiegras.ygyg.global.common.basetime.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_post")
+public class UserPostEntity extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "user_post_id")
+	private Long id;
+
+	@Column(name = "seasoning_category_idx", nullable = false, columnDefinition = "TINYINT")
+	private int seasoningCategoryIdx;
+
+	@Column(name = "writer_uuid", nullable = false, columnDefinition = "BINARY(16)")
+	private UUID writerUuid; // 포스트 작성자 uuid
+
+	@Column(name = "post_title", nullable = false, length = 50)
+	private String postTitle;
+
+	@Column(name = "expected_minimun_price", nullable = false)
+	private Integer expectedMinimumPrice;
+	// 예상 최소 소분가 = 원가 / 소분최대인원 으로 계산해 넣기
+	// 저가 순 정렬에 쓰임
+
+	@Column(name = "remain_count", nullable = false, columnDefinition = "TINYINT")
+	private Integer remain_count;
+	// 남은 참여가능 인원수 = 최대인원 - 현재인원으로 계산해 넣기
+	// 남은 인원 적은 수 순 정렬에 쓰임, 작성자 상시 포함이라 1명으로 초기화
+	// db에 넣을 때는 "--최대참여인원" 으로 넣어야 함 for 게시자 1명 기본 카운트
+
+	@Column(name = "is_full_minimum", nullable = false, columnDefinition = "TINYINT(1) DEFAULT false")
+	private Boolean isFullMinimum;
+	// 필터링 -> 최소 참여 달성된 글만 보기
+	// 추후 TODO : 소분 참여 시 다음 조건 때 True로 변경해야함 => if( isFullMinimum == FALSE && 현재인원 >= 최소참여인원 )
+
+	@Column(name = "portioning_date", nullable = false)
+	private LocalDateTime portioningDate;
+
 }

--- a/src/main/java/foiegras/ygyg/post/infrastructure/entity/UserPostEntity.java
+++ b/src/main/java/foiegras/ygyg/post/infrastructure/entity/UserPostEntity.java
@@ -22,30 +22,31 @@ public class UserPostEntity extends BaseTimeEntity {
 	@Column(name = "user_post_id")
 	private Long id;
 
-	@Column(name = "seasoning_category_idx", nullable = false, columnDefinition = "TINYINT")
-	private int seasoningCategoryIdx;
+	@Column(name = "seasoning_category_id", nullable = false, columnDefinition = "TINYINT")
+	private int seasoningCategoryId;
 
+	// 포스트 작성자 uuid
 	@Column(name = "writer_uuid", nullable = false, columnDefinition = "BINARY(16)")
-	private UUID writerUuid; // 포스트 작성자 uuid
+	private UUID writerUuid;
 
 	@Column(name = "post_title", nullable = false, length = 50)
 	private String postTitle;
 
-	@Column(name = "expected_minimun_price", nullable = false)
-	private Integer expectedMinimumPrice;
 	// 예상 최소 소분가 = 원가 / 소분최대인원 으로 계산해 넣기
 	// 저가 순 정렬에 쓰임
+	@Column(name = "expected_minimun_price", nullable = false)
+	private Integer expectedMinimumPrice;
 
-	@Column(name = "remain_count", nullable = false, columnDefinition = "TINYINT")
-	private Integer remain_count;
 	// 남은 참여가능 인원수 = 최대인원 - 현재인원으로 계산해 넣기
 	// 남은 인원 적은 수 순 정렬에 쓰임, 작성자 상시 포함이라 1명으로 초기화
 	// db에 넣을 때는 "--최대참여인원" 으로 넣어야 함 for 게시자 1명 기본 카운트
+	@Column(name = "remain_count", nullable = false, columnDefinition = "TINYINT")
+	private Integer remain_count;
 
-	@Column(name = "is_full_minimum", nullable = false, columnDefinition = "TINYINT(1) DEFAULT false")
-	private Boolean isFullMinimum;
 	// 필터링 -> 최소 참여 달성된 글만 보기
 	// 추후 TODO : 소분 참여 시 다음 조건 때 True로 변경해야함 => if( isFullMinimum == FALSE && 현재인원 >= 최소참여인원 )
+	@Column(name = "is_full_minimum", nullable = false, columnDefinition = "TINYINT(1) DEFAULT false")
+	private Boolean isFullMinimum;
 
 	@Column(name = "portioning_date", nullable = false)
 	private LocalDateTime portioningDate;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,54 @@
+# 서버 포트 설정
+server:
+  port: 8888
+
+# SpringDoc OpenAPI/Swagger 구성
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+    groups-order: DESC
+    operationsSorter: method
+    disable-swagger-default-url: true
+    display-request-duration: true
+  api-docs:
+    path: /api-docs
+  show-actuator: true
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json
+  paths-to-match:
+    - /api/v1/**
+
+# JPA 공통 설정
 spring:
-  application:
-    name: ygyg
-  profiles:
-    default: local
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+    open-in-view: false
+
+  # 이메일 템플릿 공통 설정
+  mail:
+    properties:
+      template: |
+        <div style="font-family: 'Apple SD Gothic Neo', 'sans-serif' !important; width: 540px; height: 600px; border-top: 4px solid {point_color}; margin: 100px auto; padding: 30px 0; box-sizing: border-box;">
+            <h1 style="margin: 0; padding: 0 5px; font-size: 28px; font-weight: 400;">
+               <span style="font-size: 15px; margin: 0 0 10px 3px;">Untitled</span><br />
+               <span style="color: {point_color};">메일인증</span> 안내입니다.
+            </h1>
+            <p style="font-size: 16px; line-height: 26px; margin-top: 50px; padding: 0 5px;">
+               안녕하세요.<br />
+               '야금야금'에 가입해 주셔서 진심으로 감사드립니다.<br />
+               아래 <b style="color: {point_color};">'메일 인증 번호'</b>를 입력하여 메일인증을 완료해 주세요.<br />
+               감사합니다.<br/><br/>
+            </p>
+            <b style="font-size: 40px; color: {$point_color};">메일 인증 번호 : {code}</b>
+            <br/><br/><br/>
+            <div style="border-top: 1px solid #DDD; padding: 5px;">
+               <p style="font-size: 13px; line-height: 21px; color: #555;">
+                  만약 인증번호가 정상적으로 보이지않거나 인증이 지속적으로 실패된다면 'sip0518@pusan.ac.kr'로 연락주시면 감사하겠습니다.<br />
+               </p>
+            </div>
+        </div>


### PR DESCRIPTION
# 변경점 👍
#10 
1. post_user table을 Entity 클래스로 구현, 실제 DB에 반영되는 것까지 확인 완료
2. 해당 테이블의 createdAt, updatedAt 자동화를 위해 main 클래스에 @EnableJpaAuditing 붙여둠
3. application-local.yml을 동환님 파일로 대체해둠. gitignore 포함문서라 트래킹되진 않음
 
# 스크린샷 🖼
<img width="676" alt="image" src="https://github.com/user-attachments/assets/4a225615-391b-45bd-8da6-bcc1f4aedf93">

 
# 비고 ✏
이슈넘버 부착 작업을 풀리퀘때 진행하는 거로 인지했습니다ㅠㅠ 다음 커밋부터는 반드시 커밋메시지 작성 때 하겠습니다 
 <br>
 

