### PR TITLE
[#10]feat: Category 엔티티 작성 및 user_post 엔티티와 연관관계 매핑(양뱡향, 1:N)

### DIFF
--- a/src/main/java/foiegras/ygyg/post/infrastructure/entity/SeasoningCategoryEntity.java
+++ b/src/main/java/foiegras/ygyg/post/infrastructure/entity/SeasoningCategoryEntity.java
@@ -1,0 +1,32 @@
+package foiegras.ygyg.post.infrastructure.entity;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "seasoning_category")
+public class SeasoningCategoryEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "seasoning_category_id", nullable = false, columnDefinition = "TINYINT")
+	private int id;
+
+	@Column(name = "category_name", nullable = false, length = 20)
+	private String categoryName;
+
+	// category는 연관관계 주인이 아니므로 mappedBy 속성 쓰며 속성값은 userPostEntity의 fk 속성명
+	// 양방향을 맛보기 용도로 oneToMany 지정
+	@OneToMany(mappedBy = "seasoningCategoryEntity")
+	private List<UserPostEntity> userPosts = new ArrayList<>();
+
+}

--- a/src/main/java/foiegras/ygyg/post/infrastructure/entity/UserPostEntity.java
+++ b/src/main/java/foiegras/ygyg/post/infrastructure/entity/UserPostEntity.java
@@ -22,8 +22,11 @@ public class UserPostEntity extends BaseTimeEntity {
 	@Column(name = "user_post_id")
 	private Long id;
 
-	@Column(name = "seasoning_category_id", nullable = false, columnDefinition = "TINYINT")
-	private int seasoningCategoryId;
+	// user_post가 Many, category가 One이며 양방향 맛보기로 가보기
+	// 양방향의 경우 외래키를 가진 이 엔티티가 연관관계의 주인이다.
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "seasoning_category_id")
+	private SeasoningCategoryEntity seasoningCategoryEntity;
 
 	// 포스트 작성자 uuid
 	@Column(name = "writer_uuid", nullable = false, columnDefinition = "BINARY(16)")


### PR DESCRIPTION
 #10 

# 변경점 👍
category Entity를 작성하고 user_post와 연관관계를 설정하였음.
- 전자와 후자는 1:N.
- 두 엔티티 객체 서로 참조함 => 양방향으로 설정.
    - 카테고리별 게시글 뽑아내기
    - 한 게시글의 카테고리 속성 뽑아내기

- fk가 user_post에 있으므로 매핑의 주인은 user_post
 

# 스크린샷 🖼
<img width="1278" alt="image" src="https://github.com/user-attachments/assets/94ded387-c675-4f0a-8ce3-b93f6e6e0a62">
 
# 비고 ✏
정리:  https://resolute-lychee-f4d.notion.site/8c05dce1eef34fc0ac0ab42936d85590?pvs=4 
 <br>
 

