### PR TITLE
feat: 닉네임 중복 확인 기능 구현

### DIFF
--- a/src/main/java/foiegras/ygyg/global/config/security/SecurityConfig.java
+++ b/src/main/java/foiegras/ygyg/global/config/security/SecurityConfig.java
@@ -63,7 +63,7 @@ public class SecurityConfig {
 
 	// user
 	private static final RequestMatcher[] userUrl = new RequestMatcher[] {
-		new AntPathRequestMatcher("/api/v1/user/duplicate-check/nickname", GET),   // 닉네임 중복 검사
+		new AntPathRequestMatcher("/api/v1/user/duplicate-check/nickname/**", GET),   // 닉네임 중복 검사
 	};
 
 	// post

--- a/src/main/java/foiegras/ygyg/user/api/controller/UserController.java
+++ b/src/main/java/foiegras/ygyg/user/api/controller/UserController.java
@@ -1,0 +1,47 @@
+package foiegras.ygyg.user.api.controller;
+
+
+import foiegras.ygyg.global.common.response.BaseResponse;
+import foiegras.ygyg.user.api.response.NicknameDuplicationCheckResponse;
+import foiegras.ygyg.user.application.dto.in.NicknameDuplicationCheckInDto;
+import foiegras.ygyg.user.application.dto.out.NicknameDuplicationCheckOutDto;
+import foiegras.ygyg.user.application.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.constraints.NotBlank;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@Validated
+@RestController
+@RequestMapping("/api/v1/user")
+@RequiredArgsConstructor
+public class UserController {
+
+	// service
+	private final UserService userService;
+	// util
+	private final ModelMapper modelMapper;
+
+
+	/**
+	 * UserController
+	 * 1. 닉네임 중복 확인
+	 */
+
+	// 1. 닉네임 중복 확인
+	@Operation(summary = "닉네임 중복 확인", description = "닉네임 중복 확인", tags = { "User" })
+	@GetMapping("/duplicate-check/nickname/{nickname}")
+	public BaseResponse<NicknameDuplicationCheckResponse> nicknameDuplicationCheck(@NotBlank @PathVariable("nickname") String nickname) {
+		NicknameDuplicationCheckInDto inDto = new NicknameDuplicationCheckInDto(nickname);
+		NicknameDuplicationCheckOutDto outDto = userService.nicknameDuplicationCheck(inDto);
+		NicknameDuplicationCheckResponse response = modelMapper.map(outDto, NicknameDuplicationCheckResponse.class);
+		return new BaseResponse<>(response);
+	}
+
+}

--- a/src/main/java/foiegras/ygyg/user/api/response/NicknameDuplicationCheckResponse.java
+++ b/src/main/java/foiegras/ygyg/user/api/response/NicknameDuplicationCheckResponse.java
@@ -1,0 +1,14 @@
+package foiegras.ygyg.user.api.response;
+
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@NoArgsConstructor
+public class NicknameDuplicationCheckResponse {
+
+	private Boolean isDuplicated;
+
+}

--- a/src/main/java/foiegras/ygyg/user/application/dto/in/NicknameDuplicationCheckInDto.java
+++ b/src/main/java/foiegras/ygyg/user/application/dto/in/NicknameDuplicationCheckInDto.java
@@ -1,0 +1,16 @@
+package foiegras.ygyg.user.application.dto.in;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NicknameDuplicationCheckInDto {
+
+	private String nickname;
+
+}

--- a/src/main/java/foiegras/ygyg/user/application/dto/out/NicknameDuplicationCheckOutDto.java
+++ b/src/main/java/foiegras/ygyg/user/application/dto/out/NicknameDuplicationCheckOutDto.java
@@ -1,0 +1,16 @@
+package foiegras.ygyg.user.application.dto.out;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NicknameDuplicationCheckOutDto {
+
+	private Boolean isDuplicated;
+
+}

--- a/src/main/java/foiegras/ygyg/user/application/service/UserService.java
+++ b/src/main/java/foiegras/ygyg/user/application/service/UserService.java
@@ -1,0 +1,34 @@
+package foiegras.ygyg.user.application.service;
+
+
+import foiegras.ygyg.user.application.dto.in.NicknameDuplicationCheckInDto;
+import foiegras.ygyg.user.application.dto.out.NicknameDuplicationCheckOutDto;
+import foiegras.ygyg.user.infrastructure.jpa.UserJpaRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UserService {
+
+	// repository
+	private final UserJpaRepository userJpaRepository;
+
+
+	/**
+	 * UserService
+	 * 1. 닉네임 중복 확인
+	 */
+
+	// 1. 닉네임 중복 확인
+	public NicknameDuplicationCheckOutDto nicknameDuplicationCheck(NicknameDuplicationCheckInDto inDto) {
+		Boolean isDuplicated = userJpaRepository.existsByUserNickname(inDto.getNickname());
+		return new NicknameDuplicationCheckOutDto(isDuplicated);
+	}
+
+}

--- a/src/main/java/foiegras/ygyg/user/infrastructure/jpa/UserJpaRepository.java
+++ b/src/main/java/foiegras/ygyg/user/infrastructure/jpa/UserJpaRepository.java
@@ -14,6 +14,7 @@ public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
 	 * UserJpaRepository
 	 * 1. 이메일에 해당하는 유저가 존재하는지 확인
 	 * 2. uuid로 유저 조회
+	 * 3. 닉네임으로 존재 여부 확인
 	 */
 
 	// 1. 이메일에 해당하는 유저가 존재하는지 확인
@@ -21,5 +22,8 @@ public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
 
 	// 2. uuid로 유저 조회
 	Optional<UserEntity> findByUserUuid(UUID userUuid);
+
+	// 3. 닉네임으로 존재 여부 확인
+	Boolean existsByUserNickname(String nickname);
 
 }


### PR DESCRIPTION
# Issue
- #6

# 변경점 👍
- 구현에 필요한 Controller, Service, Repository, Dto 생성
- security에 해당 api uri 허용
 
# 스크린샷 🖼
- DB 상태: 닉네임이 test 인 유저 존재
<img width="800" alt="image" src="https://github.com/user-attachments/assets/03a111e4-51db-4049-a2ef-74e3764768e9" />

- 닉네임 = test로 조회한 결과
<img width="800" alt="image" src="https://github.com/user-attachments/assets/e566d44b-f99c-4327-952a-67d80cb0b60d" />

- test가 아닌 닉네임으로 조회한 결과
<img width="800" alt="image" src="https://github.com/user-attachments/assets/7e405f4c-698e-4c39-9151-c61da0e762a6"  />
