### PR TITLE
feat: 회원가입 API 구현

### DIFF
--- a/src/main/java/foiegras/ygyg/global/common/response/BaseResponseStatus.java
+++ b/src/main/java/foiegras/ygyg/global/common/response/BaseResponseStatus.java
@@ -45,19 +45,18 @@ public enum BaseResponseStatus {
 	NO_PRIVACY_SETTINGS(HttpStatus.INTERNAL_SERVER_ERROR, false, 2008, "개인정보 설정이 존재하지 않습니다. 서버 관리자에게 문의해주세요"),
 	WRONG_AUTH_EMAIL(HttpStatus.BAD_REQUEST, false, 2009, "요청 이메일이 일치하지 않습니다"),
 	NOT_FOLLOW_SELF(HttpStatus.BAD_REQUEST, false, 2010, "본인을 팔로우할 수 없습니다"),
+	NOT_EXIST_ROUTE(HttpStatus.BAD_REQUEST, false, 2011, "존재하지 않는 방문 경로입니다."),
 
 	/**
 	 * 3000: post service error
 	 */
 	NO_EXIST_POST(HttpStatus.NOT_FOUND, false, 3001, "존재하지 않는 글입니다"),
 
-
 	/**
 	 * 4000: comment service error
 	 */
 	NO_EXIST_COMMENT(HttpStatus.NOT_FOUND, false, 4001, "존재하지 않는 댓글입니다"),
 	NO_DELETE_COMMENT_AUTHORITY(HttpStatus.BAD_REQUEST, false, 4002, "댓글 삭제 권한이 없습니다"),
-
 
 	;
 

--- a/src/main/java/foiegras/ygyg/global/common/util/UuidGenerator.java
+++ b/src/main/java/foiegras/ygyg/global/common/util/UuidGenerator.java
@@ -1,0 +1,12 @@
+package foiegras.ygyg.global.common.util;
+
+
+import java.util.UUID;
+
+
+public interface UuidGenerator {
+
+	// UUID 생성
+	UUID generateUuid();
+
+}

--- a/src/main/java/foiegras/ygyg/global/common/util/UuidGeneratorImpl.java
+++ b/src/main/java/foiegras/ygyg/global/common/util/UuidGeneratorImpl.java
@@ -1,0 +1,18 @@
+package foiegras.ygyg.global.common.util;
+
+
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+
+@Component
+public class UuidGeneratorImpl implements UuidGenerator {
+
+	// UUID 생성
+	@Override
+	public UUID generateUuid() {
+		return UUID.randomUUID();
+	}
+	
+}

--- a/src/main/java/foiegras/ygyg/global/config/security/SecurityConfig.java
+++ b/src/main/java/foiegras/ygyg/global/config/security/SecurityConfig.java
@@ -55,7 +55,7 @@ public class SecurityConfig {
 
 	// auth
 	private static final String[] authUrl = new String[] {
-		"/api/v1/user/signup",         // 회원가입
+		"/api/v1/auth/signup",         // 회원가입
 		"/api/v1/user/signin",         // 로그인
 		"/api/v1/user/password/reset",          // 유저 비밀번호 재설정
 		"/error"                                // 에러 페이지

--- a/src/main/java/foiegras/ygyg/user/api/controller/AuthController.java
+++ b/src/main/java/foiegras/ygyg/user/api/controller/AuthController.java
@@ -1,4 +1,45 @@
 package foiegras.ygyg.user.api.controller;
 
+
+import foiegras.ygyg.global.common.response.BaseResponse;
+import foiegras.ygyg.user.api.request.SignUpRequest;
+import foiegras.ygyg.user.application.dto.in.SignUpInDto;
+import foiegras.ygyg.user.application.facade.SignUpFacade;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@Validated
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
 public class AuthController {
+
+	// service
+	private final SignUpFacade signUpFacade;
+	// util
+	private final ModelMapper modelMapper;
+
+
+	/**
+	 * AuthController
+	 * 1. 회원가입
+	 */
+
+	// 1. 회원가입
+	@Operation(summary = "회원가입", description = "회원가입", tags = { "Auth" })
+	@PostMapping("/signup")
+	public BaseResponse<Void> signUp(@Valid @RequestBody SignUpRequest request) {
+		SignUpInDto inDto = modelMapper.map(request, SignUpInDto.class);
+		signUpFacade.signUp(inDto);
+		return new BaseResponse<>();
+	}
+
 }

--- a/src/main/java/foiegras/ygyg/user/api/request/SignUpRequest.java
+++ b/src/main/java/foiegras/ygyg/user/api/request/SignUpRequest.java
@@ -1,0 +1,24 @@
+package foiegras.ygyg.user.api.request;
+
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+
+@Getter
+public class SignUpRequest {
+
+	@Email
+	private String userEmail;
+	@NotBlank
+	private String userSignInId;
+	@NotBlank
+	private String userPassword;
+	@NotBlank
+	private String userNickname;
+	@NotNull
+	private Integer routeId;
+
+}

--- a/src/main/java/foiegras/ygyg/user/api/request/SingUpRequest.java
+++ b/src/main/java/foiegras/ygyg/user/api/request/SingUpRequest.java
@@ -1,4 +1,0 @@
-package foiegras.ygyg.user.api.request;
-
-public class SingUpRequest {
-}

--- a/src/main/java/foiegras/ygyg/user/api/response/SignUpResponse.java
+++ b/src/main/java/foiegras/ygyg/user/api/response/SignUpResponse.java
@@ -1,4 +1,0 @@
-package foiegras.ygyg.user.api.response;
-
-public class SignUpResponse {
-}

--- a/src/main/java/foiegras/ygyg/user/application/dto/in/CreateUserInDto.java
+++ b/src/main/java/foiegras/ygyg/user/application/dto/in/CreateUserInDto.java
@@ -1,0 +1,23 @@
+package foiegras.ygyg.user.application.dto.in;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+
+@Getter
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateUserInDto {
+
+	private UUID userUuid;
+	private String userEmail;
+	private String userPassword;
+	private String userNickname;
+
+}

--- a/src/main/java/foiegras/ygyg/user/application/dto/in/SiginInOutDto.java
+++ b/src/main/java/foiegras/ygyg/user/application/dto/in/SiginInOutDto.java
@@ -1,4 +1,0 @@
-package foiegras.ygyg.user.application.dto.in;
-
-public class SiginInOutDto {
-}

--- a/src/main/java/foiegras/ygyg/user/application/dto/in/SignUpInDto.java
+++ b/src/main/java/foiegras/ygyg/user/application/dto/in/SignUpInDto.java
@@ -1,0 +1,22 @@
+package foiegras.ygyg.user.application.dto.in;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignUpInDto {
+
+	private String userEmail;
+	private String userSignInId;
+	private String userPassword;
+	private String userNickname;
+	private Integer routeId;
+
+}

--- a/src/main/java/foiegras/ygyg/user/application/dto/out/SignUpOutDto.java
+++ b/src/main/java/foiegras/ygyg/user/application/dto/out/SignUpOutDto.java
@@ -1,4 +1,0 @@
-package foiegras.ygyg.user.application.dto.out;
-
-public class SignUpOutDto {
-}

--- a/src/main/java/foiegras/ygyg/user/application/facade/SignUpFacade.java
+++ b/src/main/java/foiegras/ygyg/user/application/facade/SignUpFacade.java
@@ -1,0 +1,61 @@
+package foiegras.ygyg.user.application.facade;
+
+
+import foiegras.ygyg.global.common.util.UuidGenerator;
+import foiegras.ygyg.user.application.dto.in.CreateUserInDto;
+import foiegras.ygyg.user.application.dto.in.SignUpInDto;
+import foiegras.ygyg.user.application.service.AuthService;
+import foiegras.ygyg.user.application.service.JoinRouteService;
+import foiegras.ygyg.user.infrastructure.entity.UserEntity;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.modelmapper.ModelMapper;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SignUpFacade {
+
+	// service
+	private final AuthService authService;
+	private final JoinRouteService joinRouteService;
+
+	// util
+	private final PasswordEncoder passwordEncoder;
+	private final UuidGenerator uuidGenerator;
+	private final ModelMapper modelMapper;
+
+
+	/**
+	 * SignUpFacade
+	 * 1. 회원가입 & 서비스 알게된 경로 카운트 증가
+	 */
+
+	// 1. 회원가입 & 서비스 알게된 경로 카운트 증가
+	public UserEntity signUp(SignUpInDto inDto) {
+		// uuid 생성
+		UUID userUuid = uuidGenerator.generateUuid();
+		// 비밀번호 암호화
+		String encodedPassword = passwordEncoder.encode(inDto.getUserPassword());
+		// 회원가입
+		CreateUserInDto createUserInDto = CreateUserInDto.builder()
+			.userUuid(userUuid)
+			.userEmail(inDto.getUserEmail())
+			.userPassword(encodedPassword)
+			.userNickname(inDto.getUserNickname())
+			.build();
+		UserEntity userEntity = authService.createUser(createUserInDto);
+		// 서비스 알게된 경로 저장
+		joinRouteService.increaseSelectRouteCount(inDto.getRouteId());
+		// 결과 return
+		return userEntity;
+	}
+
+}

--- a/src/main/java/foiegras/ygyg/user/application/service/AuthService.java
+++ b/src/main/java/foiegras/ygyg/user/application/service/AuthService.java
@@ -1,0 +1,35 @@
+package foiegras.ygyg.user.application.service;
+
+
+import foiegras.ygyg.user.application.dto.in.CreateUserInDto;
+import foiegras.ygyg.user.infrastructure.entity.UserEntity;
+import foiegras.ygyg.user.infrastructure.jpa.UserJpaRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AuthService {
+
+	// repository
+	private final UserJpaRepository userJpaRepository;
+
+
+	/**
+	 * AuthService
+	 * 1. 유저 생성
+	 * 2. 로그인
+	 */
+
+	// 1. 유저 생성
+	public UserEntity createUser(CreateUserInDto inDto) {
+		UserEntity newUser = UserEntity.createNewUser(inDto.getUserUuid(), inDto.getUserEmail(), inDto.getUserPassword(), inDto.getUserNickname());
+		return userJpaRepository.save(newUser);
+	}
+
+}

--- a/src/main/java/foiegras/ygyg/user/application/service/JoinRouteService.java
+++ b/src/main/java/foiegras/ygyg/user/application/service/JoinRouteService.java
@@ -1,0 +1,38 @@
+package foiegras.ygyg.user.application.service;
+
+
+import foiegras.ygyg.global.common.exception.BaseException;
+import foiegras.ygyg.global.common.response.BaseResponseStatus;
+import foiegras.ygyg.user.infrastructure.entity.JoinRouteEntity;
+import foiegras.ygyg.user.infrastructure.jpa.JoinRouteJpaRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class JoinRouteService {
+
+	// repository
+	private final JoinRouteJpaRepository joinRouteJpaRepository;
+
+
+	/**
+	 * JoinRouteService
+	 * 1. 서비스 알게된 경로 selectCount 증가
+	 */
+
+	// 1. 서비스 알게된 경로 selectCount 증가
+	public void increaseSelectRouteCount(Integer routeId) {
+		// 조회
+		JoinRouteEntity joinRouteEntity = joinRouteJpaRepository.findById(routeId)
+			.orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_EXIST_ROUTE));
+		// 업데이트
+		joinRouteEntity.increaseSelectCount();
+	}
+
+}

--- a/src/main/java/foiegras/ygyg/user/infrastructure/entity/UserEntity.java
+++ b/src/main/java/foiegras/ygyg/user/infrastructure/entity/UserEntity.java
@@ -38,4 +38,16 @@ public class UserEntity extends BaseTimeEntity {
 	@Builder.Default
 	private UserRole userRole = UserRole.USER;
 
+
+	// 생성자
+	public static UserEntity createNewUser(UUID userUuid, String userEmail, String userPassword, String userNickname) {
+		return UserEntity.builder()
+			.userUuid(userUuid)
+			.userEmail(userEmail)
+			.userPassword(userPassword)
+			.userNickname(userNickname)
+			.userRole(UserRole.USER)
+			.build();
+	}
+
 }


### PR DESCRIPTION
# Issue
- #6 

# 변경점 👍
- 유저 생성로직 구현
  - AuthService: CreateUserInDto를 받아서 db에 유저 저장하는 로직 구현
  - UserEntity: New User 생성하는 정적 팩토리 메서드 구현  

- 서비스 알게된 경로 카운트 증가하는 로직 구현
  - JoinRouteService: 서비스 알게된 경로의 id를 넘겨받아 카운트를 증가시키는 로직 구현

-  회원가입 API 구현
   - 회원가입 API 구현에 필요한 Controller, Service, Util Class 생성
   - SecurityConfig: 회원가입 API 경로를 인증 예외처리
 