### PR TITLE
feat: 남은 게시글 관련 테이블 엔티티 모두 구현 - post(상세조회용), ItemImageUrl(첨부사진경로용), ItemPortioningUnit(상품소분단위용)

### DIFF
--- a/src/main/java/foiegras/ygyg/post/infrastructure/entity/ItemImageUrl.java
+++ b/src/main/java/foiegras/ygyg/post/infrastructure/entity/ItemImageUrl.java
@@ -1,0 +1,28 @@
+package foiegras.ygyg.post.infrastructure.entity;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "item_image_url")
+public class ItemImageUrl {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "item_image_url_id")
+	private Long id;
+
+	@Column(name = "image_url", length = 100)
+	private String imageUrl;
+
+	@ManyToOne
+	@JoinColumn(name = "post_detail_id")
+	private PostEntity postEntity;
+
+}

--- a/src/main/java/foiegras/ygyg/post/infrastructure/entity/ItemPortioningUnit.java
+++ b/src/main/java/foiegras/ygyg/post/infrastructure/entity/ItemPortioningUnit.java
@@ -1,0 +1,24 @@
+package foiegras.ygyg.post.infrastructure.entity;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "item_portioning_unit")
+public class ItemPortioningUnit {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "item_portioning_unit_id")
+	private Long id;
+
+	@Column(name = "unit", length = 2)
+	private String unit;
+	
+}

--- a/src/main/java/foiegras/ygyg/post/infrastructure/entity/PostEntity.java
+++ b/src/main/java/foiegras/ygyg/post/infrastructure/entity/PostEntity.java
@@ -23,6 +23,11 @@ public class PostEntity {
 	@JoinColumn(name = "user_post_id")
 	private UserPostEntity userPostEntity;
 
+	// 상품소분단위 테이블과 다대일 매핑
+	@ManyToOne
+	@JoinColumn(name = "item_portining_unit_id")
+	private ItemPortioningUnit itemPortioningUnit;
+
 	//url 최대길이로 길이지정
 	@Column(name = "online_url", nullable = true, length = 2083)
 	private String onlineUrl;

--- a/src/main/java/foiegras/ygyg/post/infrastructure/entity/PostEntity.java
+++ b/src/main/java/foiegras/ygyg/post/infrastructure/entity/PostEntity.java
@@ -1,0 +1,62 @@
+package foiegras.ygyg.post.infrastructure.entity;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "post")
+public class PostEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "post_detail_id")
+	private Long id;
+
+	// userPostId(FK)가 이 엔티티에 있어야 user_post_id로 post entity 객체를 찾을 수 있다
+	@OneToOne
+	@JoinColumn(name = "user_post_id")
+	private UserPostEntity userPostEntity;
+
+	//url 최대길이로 길이지정
+	@Column(name = "online_url", nullable = true, length = 2083)
+	private String onlineUrl;
+
+	@Column(name = "original_price", nullable = false)
+	private Integer originalPrice;
+
+	@Column(name = "amount", nullable = false)
+	private Integer amount;
+
+	@Column(name = "min_engage_count", nullable = false, columnDefinition = "TINYINT")
+	private Integer minEngageCount;
+
+	@Column(name = "max_engage_count", nullable = false, columnDefinition = "TINYINT")
+	private Integer maxEngageCount;
+
+	// 게시자 포함이므로 초기값 1
+	@Column(name = "current_engage_count", nullable = false, columnDefinition = "TINYINT")
+	private Integer currentEngageCount = 1;
+
+	@Column(name = "portioning_place_latitude", nullable = false)
+	private Double portioningPlaceLatitude;
+
+	@Column(name = "portioning_place_longitude", nullable = false)
+	private Double portioningPlaceLongitude;
+
+	@Column(name = "description", nullable = false, columnDefinition = "TEXT")
+	private String description;
+
+	// 단순 길이제한은 columnDefinition 대신 length 옵션으로~
+	@Column(name = "portioning_place_address", length = 100, nullable = false)
+	private String portioningPlaceAddress;
+
+	@Column(name = "portioning_place_detail_address", length = 100, nullable = false)
+	private String portioningPlaceDetailAddress;
+
+}


### PR DESCRIPTION
# 변경점 👍
남은 3개 엔티티를 작성했고 연관관계를 매핑해놨습니다

 
# 비고 ✏
상품 사진 경로 엔티티에서 imageUrl 속성에서 의문점이 든 사항이 있습니다.
erd상에서 varchar(100)으로 돼있는데 경로길이가 100으로 충분할지 조심스러웠습니다. 
그래서 post상의 onlineUrl은 경로최대길이 2083자로 설정해놨습니다.
aws s3로 지정되는 이미지 경로는 대부분 100자 이하로 나오게 돼서 그런건가요?
 <br>
 

