### PR TITLE
modify: auth 관련 permit URL 수정 및 swagger config 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,8 @@ dependencies {
     implementation group: 'org.modelmapper', name: 'modelmapper', version: '3.0.0'
     // email
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/foiegras/ygyg/global/common/redis/RedisUtil.java
+++ b/src/main/java/foiegras/ygyg/global/common/redis/RedisUtil.java
@@ -1,0 +1,49 @@
+package foiegras.ygyg.global.common.redis;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RedisUtil {
+
+	private final StringRedisTemplate template;
+	private final RedisTemplate<String, Integer> integerTemplate;
+
+
+	// 값 가져오기
+	public String getData(String key) {
+		ValueOperations<String, String> valueOperations = template.opsForValue();
+		return valueOperations.get(key);
+	}
+
+
+	// 값 존재 여부
+	public boolean existData(String key) {
+		return Boolean.TRUE.equals(template.hasKey(key));
+	}
+
+
+	// 값 저장 및 만료 시간 설정
+	public void createDataExpire(String key, String value, long duration) {
+		ValueOperations<String, String> valueOperations = template.opsForValue();
+		Duration expireDuration = Duration.ofSeconds(duration);
+		valueOperations.set(key, value, expireDuration);
+	}
+
+
+	// 값 삭제
+	public void deleteData(String key) {
+		template.delete(key);
+	}
+
+}

--- a/src/main/java/foiegras/ygyg/global/config/redis/RedisConfig.java
+++ b/src/main/java/foiegras/ygyg/global/config/redis/RedisConfig.java
@@ -1,0 +1,91 @@
+package foiegras.ygyg.global.config.redis;
+
+
+import io.lettuce.core.RedisClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+
+@Configuration
+@EnableRedisRepositories // RedisRepository를 사용하기 위해 필요
+public class RedisConfig {
+
+	@Value("${spring.data.redis.port}")
+	private int port;
+
+	@Value("${spring.data.redis.host}")
+	private String host;
+
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		return new LettuceConnectionFactory(host, port);
+	}
+
+
+	@Bean
+	@Primary // 여러 개의 Bean 중에서 우선적으로 사용할 Bean을 지정
+	public RedisTemplate<String, String> redisTemplate() {
+		// redisTemplate를 받아와서 set, get, delete를 사용
+		RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+
+		/**
+		 * setKeySerializer, setValueSerializer 설정
+		 * Serializer: 직렬화로 데이터 저장 시 데이터를 바이트 배열로 변환하는 과정
+		 * redis-cli을 통해 직접 데이터를 조회 시 알아볼 수 없는 형태로 출력되는 것을 방지
+		 * 아래 두 라인을 작성하지 않으면, key값이 \xac\xed\x00\x05t\x00\x03sol 이렇게 조회된다.
+		 */
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+		// redisTemplate에 redisConnectionFactory를 넣어 Spring Data Redis가 사용할 수 있도록 설정
+		redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+		return redisTemplate;
+	}
+
+
+	@Bean
+	public RedisClient redisClient() {
+		return RedisClient.create("redis://" + host + ":" + port);
+	}
+
+
+	@Bean
+	public RedisCacheConfiguration cacheConfiguration() {
+		return RedisCacheConfiguration.defaultCacheConfig()
+			.serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
+			.disableCachingNullValues();
+	}
+
+
+	@Bean
+	public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+		return RedisCacheManager.builder(redisConnectionFactory)
+			.cacheDefaults(cacheConfiguration())
+			.build();
+	}
+
+
+	@Bean
+	public RedisTemplate<String, Integer> redisIntegerTemplate() {
+		RedisTemplate<String, Integer> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+		redisTemplate.setConnectionFactory(redisConnectionFactory());
+		return redisTemplate;
+	}
+
+}

--- a/src/main/java/foiegras/ygyg/global/config/security/SecurityConfig.java
+++ b/src/main/java/foiegras/ygyg/global/config/security/SecurityConfig.java
@@ -48,8 +48,8 @@ public class SecurityConfig {
 
 	// email
 	private static final RequestMatcher[] emailUrl = new RequestMatcher[] {
-		new AntPathRequestMatcher("/api/v1/user/duplicate-check/email", GET),   // 이메일 중복 검사
-		new AntPathRequestMatcher("/api/v1/user/auth-email", POST),             // 인증 이메일 전송
+		new AntPathRequestMatcher("/api/v1/email/duplicate-check", GET),   // 이메일 중복 검사
+		new AntPathRequestMatcher("/api/v1/email/auth", POST),             // 인증 이메일 전송
 		new AntPathRequestMatcher("/api/v1/user/verify/email", GET),            // 이메일 인증 코드 확인
 	};
 

--- a/src/main/java/foiegras/ygyg/global/config/security/SecurityConfig.java
+++ b/src/main/java/foiegras/ygyg/global/config/security/SecurityConfig.java
@@ -50,7 +50,7 @@ public class SecurityConfig {
 	private static final RequestMatcher[] emailUrl = new RequestMatcher[] {
 		new AntPathRequestMatcher("/api/v1/email/duplicate-check", GET),   // 이메일 중복 검사
 		new AntPathRequestMatcher("/api/v1/email/auth", POST),             // 인증 이메일 전송
-		new AntPathRequestMatcher("/api/v1/user/verify/email", GET),            // 이메일 인증 코드 확인
+		new AntPathRequestMatcher("/api/v1/email/verify/auth-code", GET),            // 이메일 인증 코드 확인
 	};
 
 	// auth

--- a/src/main/java/foiegras/ygyg/global/config/security/SecurityConfig.java
+++ b/src/main/java/foiegras/ygyg/global/config/security/SecurityConfig.java
@@ -54,11 +54,10 @@ public class SecurityConfig {
 	};
 
 	// auth
-	private static final String[] authUrl = new String[] {
-		"/api/v1/auth/signup",         // 회원가입
-		"/api/v1/auth/signin",         // 로그인
-		"/api/v1/user/password/reset",          // 유저 비밀번호 재설정
-		"/error"                                // 에러 페이지
+	private static final RequestMatcher[] authUrl = new RequestMatcher[] {
+		new AntPathRequestMatcher("/api/v1/auth/signup", POST),         // 회원가입
+		new AntPathRequestMatcher("/api/v1/auth/signin", POST),         // 로그인
+		new AntPathRequestMatcher("/api/v1/user/password/reset", PUT)          // 유저 비밀번호 재설정
 	};
 
 	// user
@@ -93,6 +92,7 @@ public class SecurityConfig {
 				// 예비 요청을 허용
 				.requestMatchers(org.springframework.web.cors.CorsUtils::isPreFlightRequest).permitAll()
 				// 로그인 없이 허용할 url
+				.requestMatchers("/error").permitAll()
 				.requestMatchers(userUrl).permitAll()
 				.requestMatchers(authUrl).permitAll()
 				.requestMatchers(emailUrl).permitAll()

--- a/src/main/java/foiegras/ygyg/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/foiegras/ygyg/global/config/swagger/SwaggerConfig.java
@@ -7,7 +7,6 @@ import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 
 
 @OpenAPIDefinition(
@@ -24,7 +23,6 @@ import org.springframework.context.annotation.Profile;
 	scheme = "bearer"
 )
 
-@Profile("!prod")
 @Configuration
 public class SwaggerConfig {
 

--- a/src/main/java/foiegras/ygyg/user/api/controller/EmailController.java
+++ b/src/main/java/foiegras/ygyg/user/api/controller/EmailController.java
@@ -2,30 +2,32 @@ package foiegras.ygyg.user.api.controller;
 
 
 import foiegras.ygyg.global.common.response.BaseResponse;
+import foiegras.ygyg.user.api.request.SendAuthenticationEmailRequest;
 import foiegras.ygyg.user.api.response.CheckEmailDuplicateResponse;
+import foiegras.ygyg.user.application.dto.in.SendAuthenticationEmailInDto;
 import foiegras.ygyg.user.application.dto.out.CheckEmailDuplicateOutDto;
+import foiegras.ygyg.user.application.facade.SendAuthEmailFacade;
 import foiegras.ygyg.user.application.service.EmailService;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 
 @Validated
 @RestController
-@RequestMapping("/api/v1/user")
+@RequestMapping("/api/v1/email")
 @RequiredArgsConstructor
 public class EmailController {
 
 	// service
 	private final EmailService emailService;
+	private final SendAuthEmailFacade sendAuthEmailFacade;
 	// util
 	private final ModelMapper modelMapper;
 
@@ -33,15 +35,26 @@ public class EmailController {
 	/**
 	 * EmailController
 	 * 1. 이메일 중복 확인
+	 * 2. 인증 메일 전송
 	 */
 
 	// 1. 이메일 중복 확인
-	@Operation(summary = "이메일 중복 확인", description = "이메일 중복 확인", tags = { "User Sign" })
-	@GetMapping("/duplicate-check/email")
+	@Operation(summary = "이메일 중복 확인", description = "이메일 중복 확인", tags = { "Email" })
+	@GetMapping("/duplicate-check")
 	public BaseResponse<CheckEmailDuplicateResponse> checkDuplicateEmail(@Email @NotBlank @Size(max = 50) @RequestParam("email") String email) {
 		CheckEmailDuplicateOutDto checkEmailDuplicateOutDto = emailService.checkDuplicateEmail(email);
 		CheckEmailDuplicateResponse checkEmailDuplicateResponse = modelMapper.map(checkEmailDuplicateOutDto, CheckEmailDuplicateResponse.class);
 		return new BaseResponse<>(checkEmailDuplicateResponse);
+	}
+
+
+	// 2. 인증 메일 전송
+	@Operation(summary = "인증 이메일 전송", description = "인증 이메일 전송", tags = { "Email" })
+	@PostMapping("/auth")
+	public BaseResponse<Void> sendAuthenticationEmail(@Valid @RequestBody SendAuthenticationEmailRequest request) {
+		SendAuthenticationEmailInDto inDto = modelMapper.map(request, SendAuthenticationEmailInDto.class);
+		sendAuthEmailFacade.sendAuthenticationEmail(inDto);
+		return new BaseResponse<>();
 	}
 
 }

--- a/src/main/java/foiegras/ygyg/user/api/controller/EmailController.java
+++ b/src/main/java/foiegras/ygyg/user/api/controller/EmailController.java
@@ -3,10 +3,15 @@ package foiegras.ygyg.user.api.controller;
 
 import foiegras.ygyg.global.common.response.BaseResponse;
 import foiegras.ygyg.user.api.request.SendAuthenticationEmailRequest;
+import foiegras.ygyg.user.api.request.VerifyAuthCodeRequest;
 import foiegras.ygyg.user.api.response.CheckEmailDuplicateResponse;
+import foiegras.ygyg.user.api.response.VerifyAuthCodeResponse;
 import foiegras.ygyg.user.application.dto.in.SendAuthenticationEmailInDto;
+import foiegras.ygyg.user.application.dto.in.VerifyAuthCodeInDto;
 import foiegras.ygyg.user.application.dto.out.CheckEmailDuplicateOutDto;
+import foiegras.ygyg.user.application.dto.out.VerifyAuthCodeOutDto;
 import foiegras.ygyg.user.application.facade.SendAuthEmailFacade;
+import foiegras.ygyg.user.application.service.AuthEmailService;
 import foiegras.ygyg.user.application.service.EmailService;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
@@ -28,6 +33,7 @@ public class EmailController {
 	// service
 	private final EmailService emailService;
 	private final SendAuthEmailFacade sendAuthEmailFacade;
+	private final AuthEmailService authEmailService;
 	// util
 	private final ModelMapper modelMapper;
 
@@ -36,6 +42,7 @@ public class EmailController {
 	 * EmailController
 	 * 1. 이메일 중복 확인
 	 * 2. 인증 메일 전송
+	 * 3. 이메일 인증 코드 확인
 	 */
 
 	// 1. 이메일 중복 확인
@@ -55,6 +62,17 @@ public class EmailController {
 		SendAuthenticationEmailInDto inDto = modelMapper.map(request, SendAuthenticationEmailInDto.class);
 		sendAuthEmailFacade.sendAuthenticationEmail(inDto);
 		return new BaseResponse<>();
+	}
+
+
+	// 3. 이메일 인증 코드 확인
+	@Operation(summary = "이메일 인증 코드 확인", description = "이메일 인증 코드 확인", tags = { "Email" })
+	@GetMapping("/verify/auth-code")
+	public BaseResponse<VerifyAuthCodeResponse> verifyAuthCode(@Valid VerifyAuthCodeRequest request) {
+		VerifyAuthCodeInDto inDto = modelMapper.map(request, VerifyAuthCodeInDto.class);
+		VerifyAuthCodeOutDto outDto = authEmailService.verifyAuthCode(inDto);
+		VerifyAuthCodeResponse responseDto = modelMapper.map(outDto, VerifyAuthCodeResponse.class);
+		return new BaseResponse<>(responseDto);
 	}
 
 }

--- a/src/main/java/foiegras/ygyg/user/api/request/SendAuthenticationEmailRequest.java
+++ b/src/main/java/foiegras/ygyg/user/api/request/SendAuthenticationEmailRequest.java
@@ -1,0 +1,14 @@
+package foiegras.ygyg.user.api.request;
+
+
+import jakarta.validation.constraints.Email;
+import lombok.Getter;
+
+
+@Getter
+public class SendAuthenticationEmailRequest {
+
+	@Email
+	private String userEmail;
+
+}

--- a/src/main/java/foiegras/ygyg/user/api/request/SignInRequest.java
+++ b/src/main/java/foiegras/ygyg/user/api/request/SignInRequest.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @Getter
 public class SignInRequest {
 
-	private String userSignInId;
+	private String userEmail;
 	private String userPassword;
 
 }

--- a/src/main/java/foiegras/ygyg/user/api/request/SignUpRequest.java
+++ b/src/main/java/foiegras/ygyg/user/api/request/SignUpRequest.java
@@ -13,8 +13,6 @@ public class SignUpRequest {
 	@Email
 	private String userEmail;
 	@NotBlank
-	private String userSignInId;
-	@NotBlank
 	private String userPassword;
 	@NotBlank
 	private String userNickname;

--- a/src/main/java/foiegras/ygyg/user/api/request/VerifyAuthCodeRequest.java
+++ b/src/main/java/foiegras/ygyg/user/api/request/VerifyAuthCodeRequest.java
@@ -1,0 +1,22 @@
+package foiegras.ygyg.user.api.request;
+
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+
+@Getter
+@AllArgsConstructor
+public class VerifyAuthCodeRequest {
+
+	@Email
+	private String userEmail;
+
+	@NotEmpty(message = "인증 코드를 입력해주세요.")
+	@Size(min = 6, max = 6, message = "인증 코드는 6자리로 입력해주세요.")
+	private String authCode;
+
+}

--- a/src/main/java/foiegras/ygyg/user/api/response/VerifyAuthCodeResponse.java
+++ b/src/main/java/foiegras/ygyg/user/api/response/VerifyAuthCodeResponse.java
@@ -1,0 +1,13 @@
+package foiegras.ygyg.user.api.response;
+
+
+import lombok.Getter;
+
+
+@Getter
+public class VerifyAuthCodeResponse {
+
+	private Boolean isVerified;
+
+}
+

--- a/src/main/java/foiegras/ygyg/user/application/dto/in/CreateUserInDto.java
+++ b/src/main/java/foiegras/ygyg/user/application/dto/in/CreateUserInDto.java
@@ -16,7 +16,6 @@ import java.util.UUID;
 public class CreateUserInDto {
 
 	private UUID userUuid;
-	private String userSignInId;
 	private String userEmail;
 	private String userPassword;
 	private String userNickname;

--- a/src/main/java/foiegras/ygyg/user/application/dto/in/SendAuthenticationEmailInDto.java
+++ b/src/main/java/foiegras/ygyg/user/application/dto/in/SendAuthenticationEmailInDto.java
@@ -1,0 +1,16 @@
+package foiegras.ygyg.user.application.dto.in;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SendAuthenticationEmailInDto {
+
+	private String userEmail;
+
+}

--- a/src/main/java/foiegras/ygyg/user/application/dto/in/SignInInDto.java
+++ b/src/main/java/foiegras/ygyg/user/application/dto/in/SignInInDto.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class SignInInDto {
 
-	private String userSignInId;
+	private String userEmail;
 	private String userPassword;
-	
+
 }

--- a/src/main/java/foiegras/ygyg/user/application/dto/in/SignUpInDto.java
+++ b/src/main/java/foiegras/ygyg/user/application/dto/in/SignUpInDto.java
@@ -14,7 +14,6 @@ import lombok.NoArgsConstructor;
 public class SignUpInDto {
 
 	private String userEmail;
-	private String userSignInId;
 	private String userPassword;
 	private String userNickname;
 	private Integer routeId;

--- a/src/main/java/foiegras/ygyg/user/application/dto/in/VerifyAuthCodeInDto.java
+++ b/src/main/java/foiegras/ygyg/user/application/dto/in/VerifyAuthCodeInDto.java
@@ -1,0 +1,17 @@
+package foiegras.ygyg.user.application.dto.in;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class VerifyAuthCodeInDto {
+
+	private String userEmail;
+	private String authCode;
+
+}

--- a/src/main/java/foiegras/ygyg/user/application/dto/out/SendEmailOutDto.java
+++ b/src/main/java/foiegras/ygyg/user/application/dto/out/SendEmailOutDto.java
@@ -1,0 +1,21 @@
+package foiegras.ygyg.user.application.dto.out;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+
+@Getter
+@Builder
+public class SendEmailOutDto {
+
+	// 수신자 email
+	private String receiverEmail;
+	// 제목
+	private String subject;
+	// 내용
+	private String text;
+	// 코드
+	private String code;
+
+}

--- a/src/main/java/foiegras/ygyg/user/application/dto/out/VerifyAuthCodeOutDto.java
+++ b/src/main/java/foiegras/ygyg/user/application/dto/out/VerifyAuthCodeOutDto.java
@@ -1,0 +1,16 @@
+package foiegras.ygyg.user.application.dto.out;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class VerifyAuthCodeOutDto {
+
+	private Boolean isVerified;
+
+}

--- a/src/main/java/foiegras/ygyg/user/application/facade/SendAuthEmailFacade.java
+++ b/src/main/java/foiegras/ygyg/user/application/facade/SendAuthEmailFacade.java
@@ -1,0 +1,35 @@
+package foiegras.ygyg.user.application.facade;
+
+
+import foiegras.ygyg.user.application.dto.in.SendAuthenticationEmailInDto;
+import foiegras.ygyg.user.application.dto.out.SendEmailOutDto;
+import foiegras.ygyg.user.application.service.AuthEmailService;
+import foiegras.ygyg.user.application.service.EmailService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SendAuthEmailFacade {
+
+	// service
+	private final AuthEmailService authEmailService;
+	private final EmailService emailService;
+
+
+	// 인증 메일 전송
+	public void sendAuthenticationEmail(SendAuthenticationEmailInDto inDto) {
+		// 이메일 내용 생성
+		SendEmailOutDto authEmailContent = authEmailService.createAuthEmail(inDto.getUserEmail());
+		// 이메일 전송
+		emailService.sendEmail(authEmailContent);
+		// 레디스에 저장
+		authEmailService.saveAuthenticationCode(inDto.getUserEmail(), authEmailContent.getCode());
+	}
+
+}

--- a/src/main/java/foiegras/ygyg/user/application/facade/SignInFacade.java
+++ b/src/main/java/foiegras/ygyg/user/application/facade/SignInFacade.java
@@ -31,7 +31,7 @@ public class SignInFacade {
 	// 1. 로그인
 	public SignInOutDto signIn(SignInInDto inDto) {
 		// user 조회
-		UserEntity user = userService.findBySignInId(inDto.getUserSignInId());
+		UserEntity user = userService.findByUserEmail(inDto.getUserEmail());
 		// user, pw로 인증 진행
 		authService.authenticate(user, inDto.getUserPassword());
 		// 인증에 성공했다면 토큰 생성

--- a/src/main/java/foiegras/ygyg/user/application/facade/SignUpFacade.java
+++ b/src/main/java/foiegras/ygyg/user/application/facade/SignUpFacade.java
@@ -47,7 +47,6 @@ public class SignUpFacade {
 		// 회원가입
 		CreateUserInDto createUserInDto = CreateUserInDto.builder()
 			.userUuid(userUuid)
-			.userSignInId(inDto.getUserSignInId())
 			.userEmail(inDto.getUserEmail())
 			.userPassword(encodedPassword)
 			.userNickname(inDto.getUserNickname())

--- a/src/main/java/foiegras/ygyg/user/application/service/AuthEmailService.java
+++ b/src/main/java/foiegras/ygyg/user/application/service/AuthEmailService.java
@@ -1,0 +1,60 @@
+package foiegras.ygyg.user.application.service;
+
+
+import foiegras.ygyg.global.common.redis.RedisUtil;
+import foiegras.ygyg.user.application.dto.out.SendEmailOutDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthEmailService {
+
+	// util
+	private final RedisUtil redisUtil;
+	// value
+	@Value("${spring.mail.template}")
+	private String emailContent;
+	@Value("${spring.mail.properties.auth-code-expiration-sec}")
+	private Long expireMillis;
+	@Value("${spring.mail.subject}")
+	private String subject;
+
+
+	/**
+	 * AuthEmailSenderImpl
+	 * 1. 인증 이메일 내용 생성
+	 * 2. redis 에 인증코드 저장
+	 */
+
+	// 1. 인증 이메일 내용 생성
+	public SendEmailOutDto createAuthEmail(String userEmail) {
+		// 인증 코드 생성
+		String code = String.valueOf((int) (Math.random() * 900000) + 100000);
+		// 이메일 내용 설정
+		String codeInjectedContent = emailContent.replace("{code}", code);
+		// 이메일 설정
+		return SendEmailOutDto.builder()
+			.receiverEmail(userEmail)
+			.subject(subject)
+			.text(codeInjectedContent)
+			.code(code)
+			.build();
+	}
+
+
+	// 2. redis 에 인증코드 저장
+	public void saveAuthenticationCode(String userEmail, String code) {
+		String codeKey = "AUTH_EMAIL::" + userEmail;
+		// redis에서 이메일 중복 여부 확인
+		if (redisUtil.existData(codeKey)) {
+			redisUtil.deleteData(userEmail);
+		}
+		redisUtil.createDataExpire(codeKey, code, expireMillis);
+	}
+
+}

--- a/src/main/java/foiegras/ygyg/user/application/service/AuthService.java
+++ b/src/main/java/foiegras/ygyg/user/application/service/AuthService.java
@@ -38,7 +38,7 @@ public class AuthService {
 
 	// 1. 유저 생성
 	public UserEntity createUser(CreateUserInDto inDto) {
-		UserEntity newUser = UserEntity.createNewUser(inDto.getUserUuid(), inDto.getUserSignInId(), inDto.getUserEmail(), inDto.getUserPassword(), inDto.getUserNickname());
+		UserEntity newUser = UserEntity.createNewUser(inDto.getUserUuid(), inDto.getUserEmail(), inDto.getUserPassword(), inDto.getUserNickname());
 		return userJpaRepository.save(newUser);
 	}
 

--- a/src/main/java/foiegras/ygyg/user/application/service/EmailService.java
+++ b/src/main/java/foiegras/ygyg/user/application/service/EmailService.java
@@ -1,11 +1,17 @@
 package foiegras.ygyg.user.application.service;
 
 
+import foiegras.ygyg.global.common.exception.BaseException;
+import foiegras.ygyg.global.common.response.BaseResponseStatus;
 import foiegras.ygyg.user.application.dto.out.CheckEmailDuplicateOutDto;
+import foiegras.ygyg.user.application.dto.out.SendEmailOutDto;
 import foiegras.ygyg.user.infrastructure.jpa.UserJpaRepository;
+import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,20 +22,46 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class EmailService {
 
+	// repository
 	private final UserJpaRepository userJpaRepository;
 	// util
 	private final JavaMailSender mailSender;
+	// value
+	@Value("${spring.mail.username}")
+	private String fromEmail;
 
 
 	/**
 	 * EmailService
 	 * 1. 이메일 중복 확인
+	 * 2. 이메일 전송
 	 */
 
 	// 1. 이메일 중복 확인
 	@Transactional(readOnly = true)
 	public CheckEmailDuplicateOutDto checkDuplicateEmail(String email) {
 		return new CheckEmailDuplicateOutDto(userJpaRepository.existsByUserEmail(email));
+	}
+
+
+	// 2. 이메일 전송
+	@Async
+	public void sendEmail(SendEmailOutDto outDto) {
+		// MimeMessage 생성
+		MimeMessage email = mailSender.createMimeMessage();
+		// 내용 설정
+		try {
+			email.setSubject(outDto.getSubject());
+			email.setText(outDto.getText(), "UTF-8", "html");
+			email.setRecipients(MimeMessage.RecipientType.TO, outDto.getReceiverEmail());
+			email.setFrom(fromEmail);
+			log.info("MimeMessage 생성 성공: {}", email);
+		} catch (Exception e) {
+			log.error("MimeMessage 생성 실패, 이메일을 다시 확인해주세요: {}", outDto.getReceiverEmail());
+			throw new BaseException(BaseResponseStatus.INVALID_EMAIL_ADDRESS);
+		}
+		// 메일 전송
+		mailSender.send(email);
 	}
 
 }

--- a/src/main/java/foiegras/ygyg/user/application/service/UserService.java
+++ b/src/main/java/foiegras/ygyg/user/application/service/UserService.java
@@ -26,7 +26,7 @@ public class UserService {
 	/**
 	 * UserService
 	 * 1. 닉네임 중복 확인
-	 * 2. 로그인 Id로 유저 조회
+	 * 2. 이메일로 유저 조회
 	 */
 
 	// 1. 닉네임 중복 확인
@@ -37,8 +37,8 @@ public class UserService {
 
 
 	// 2. 로그인 Id로 유저 조회
-	public UserEntity findBySignInId(String userSignInId) {
-		return userJpaRepository.findByUserSignInId(userSignInId)
+	public UserEntity findByUserEmail(String userEmail) {
+		return userJpaRepository.findByUserEmail(userEmail)
 			.orElseThrow(() -> new BaseException(BaseResponseStatus.FAILED_TO_LOGIN));
 	}
 

--- a/src/main/java/foiegras/ygyg/user/infrastructure/entity/UserEntity.java
+++ b/src/main/java/foiegras/ygyg/user/infrastructure/entity/UserEntity.java
@@ -25,9 +25,6 @@ public class UserEntity extends BaseTimeEntity {
 	@Column(name = "user_uuid", nullable = false, columnDefinition = "BINARY(16)")
 	private UUID userUuid;
 
-	@Column(name = "user_sign_in_id", length = 100, nullable = false)
-	private String userSignInId;
-
 	@Column(name = "user_email", length = 100, nullable = false)
 	private String userEmail;
 
@@ -43,10 +40,9 @@ public class UserEntity extends BaseTimeEntity {
 
 
 	// 생성자
-	public static UserEntity createNewUser(UUID userUuid, String userSignInId, String userEmail, String userPassword, String userNickname) {
+	public static UserEntity createNewUser(UUID userUuid, String userEmail, String userPassword, String userNickname) {
 		return UserEntity.builder()
 			.userUuid(userUuid)
-			.userSignInId(userSignInId)
 			.userEmail(userEmail)
 			.userPassword(userPassword)
 			.userNickname(userNickname)

--- a/src/main/java/foiegras/ygyg/user/infrastructure/jpa/UserJpaRepository.java
+++ b/src/main/java/foiegras/ygyg/user/infrastructure/jpa/UserJpaRepository.java
@@ -26,6 +26,6 @@ public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
 	// 3. 닉네임으로 존재 여부 확인
 	Boolean existsByUserNickname(String nickname);
 
-	Optional<UserEntity> findByUserSignInId(String userSignInId);
+	Optional<UserEntity> findByUserEmail(String userEmail);
 
 }


### PR DESCRIPTION
# Issue
- #6 

# 변경점 👍
- Auth Permit URL을 String[]에서 RequestMatcher[]로 좀 더 정확하게 수정
- Swagger를 'prod' 환경에서도 사용할 수 있도록 수정
 
# 비고 ✏
- 다음 commit 내역들이 develop에서 지워져서 다시 merge 시도
  - [feat: 인증 메일 전송 api 구현](https://github.com/ApptiveDev/ygyg-be/commit/d006e9e94a4d3e88b978c41769d4c750c0241caf)
  - [feat: 인증 코드 확인 api 구현](https://github.com/ApptiveDev/ygyg-be/commit/8d4b4af2c18982308bef31dc9dbcc181923f8c80)
  - [modify: UserSignInId를 UserEmail로 대체](https://github.com/ApptiveDev/ygyg-be/commit/9ab32d524f43829bc8fbde7ed57a1411773fa1ab)