### PR TITLE
feat: 소분 상세조회 API 개발

### DIFF
--- a/src/main/java/foiegras/ygyg/global/common/response/BaseResponseStatus.java
+++ b/src/main/java/foiegras/ygyg/global/common/response/BaseResponseStatus.java
@@ -53,6 +53,10 @@ public enum BaseResponseStatus {
 	NO_EXIST_POST(HttpStatus.NOT_FOUND, false, 3001, "존재하지 않는 글입니다"),
 	NO_EXIST_CATEGORY(HttpStatus.NOT_FOUND, false, 3002, "존재하지 않는 카테고리입니다."),
 	NO_EXIST_UNIT(HttpStatus.NOT_FOUND, false, 3003, "존재하지 않는 소분단위입니다."),
+	NO_EXIST_USER_POST_ENTITY(HttpStatus.NOT_FOUND, false, 3004, "user_post가 존재하지 않습니다."),
+	NO_EXIST_PARTICIPATING_USERS(HttpStatus.NOT_FOUND, false, 3005, "해당 게시글에 참여자 정보가 존재하지 않습니다."),
+	NO_EXIST_POST_ENTITY(HttpStatus.NOT_FOUND, false, 3006, "post가 존재하지 않습니다."),
+	NO_EXIST_ITEM_IMAGE_URL_ENTITY(HttpStatus.NOT_FOUND, false, 3007, "item_image_url이 존재하지 않습니다"),
 
 	/**
 	 * 4000: comment service error

--- a/src/main/java/foiegras/ygyg/post/api/controller/PostController.java
+++ b/src/main/java/foiegras/ygyg/post/api/controller/PostController.java
@@ -55,7 +55,7 @@ public class PostController {
 	@Operation(summary = "소분글 상세조회", description = "소분글 상세조회", tags = { "Post" })
 	@GetMapping("/{userPostId}")
 	@SecurityRequirement(name = "Bearer Auth")
-	public BaseResponse<GetPostInDto> getPost(@PathVariable Long userPostId, @AuthenticationPrincipal CustomUserDetails authentication) {
+	public BaseResponse<GetPostResponse> getPost(@PathVariable Long userPostId, @AuthenticationPrincipal CustomUserDetails authentication) {
 		GetPostInDto inDto = GetPostInDto.builder()
 			.userPostId(userPostId)
 			.userUuid(authentication.getUserUuid())

--- a/src/main/java/foiegras/ygyg/post/api/controller/PostController.java
+++ b/src/main/java/foiegras/ygyg/post/api/controller/PostController.java
@@ -52,6 +52,7 @@ public class PostController {
 	// 2. 소분글 상세조회
 	@Operation(summary = "소분글 상세조회", description = "소분글 상세조회", tags = { "Post" })
 	@GetMapping("/{userPostId}")
+	@SecurityRequirement(name = "Bearer Auth")
 	public BaseResponse<GetPostInDto> getPost(@PathVariable Long userPostId) {
 		GetPostInDto inDto = new GetPostInDto(userPostId);
 		GetPostOutDto outDto = postService.getPost(inDto);

--- a/src/main/java/foiegras/ygyg/post/api/controller/PostController.java
+++ b/src/main/java/foiegras/ygyg/post/api/controller/PostController.java
@@ -55,7 +55,7 @@ public class PostController {
 	@Operation(summary = "소분글 상세조회", description = "소분글 상세조회", tags = { "Post" })
 	@GetMapping("/{userPostId}")
 	@SecurityRequirement(name = "Bearer Auth")
-	public BaseResponse<GetPostResponse> getPost(@PathVariable Long userPostId, @AuthenticationPrincipal CustomUserDetails authentication) {
+	public BaseResponse<GetPostResponse> getPost(@PathVariable("userPostId") Long userPostId, @AuthenticationPrincipal CustomUserDetails authentication) {
 		GetPostInDto inDto = GetPostInDto.builder()
 			.userPostId(userPostId)
 			.userUuid(authentication.getUserUuid())

--- a/src/main/java/foiegras/ygyg/post/api/controller/PostController.java
+++ b/src/main/java/foiegras/ygyg/post/api/controller/PostController.java
@@ -3,7 +3,10 @@ package foiegras.ygyg.post.api.controller;
 
 import foiegras.ygyg.global.common.response.BaseResponse;
 import foiegras.ygyg.post.api.request.CreatePostRequest;
+import foiegras.ygyg.post.api.response.GetPostResponse;
 import foiegras.ygyg.post.application.dto.in.CreatePostInDto;
+import foiegras.ygyg.post.application.dto.in.GetPostInDto;
+import foiegras.ygyg.post.application.dto.in.GetPostOutDto;
 import foiegras.ygyg.post.application.service.PostService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -11,10 +14,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 
 @RestController
@@ -33,9 +33,9 @@ public class PostController {
 	/**
 	 * PostController - 기본적인 post crud 처리
 	 * 1. 소분글 생성
-	 * 2. 소분글 수정
+	 * 2. 소분글 상세조회
 	 * 3. 소분글 삭제
-	 * 4. 소분글 상세조회
+	 * 4. 소분글 수정
 	 */
 
 	// 1. 소분글 게시
@@ -46,6 +46,17 @@ public class PostController {
 		CreatePostInDto indto = modelMapper.map(request, CreatePostInDto.class);
 		postService.createPost(indto);
 		return new BaseResponse<>();
+	}
+
+
+	// 2. 소분글 상세조회
+	@Operation(summary = "소분글 상세조회", description = "소분글 상세조회", tags = { "Post" })
+	@GetMapping("/{userPostId}")
+	public BaseResponse<GetPostInDto> getPost(@PathVariable Long userPostId) {
+		GetPostInDto inDto = new GetPostInDto(userPostId);
+		GetPostOutDto outDto = postService.getPost(inDto);
+		GetPostResponse response = modelMapper.map(outDto, GetPostResponse.class);
+		return new BaseResponse<>(response);
 	}
 
 }

--- a/src/main/java/foiegras/ygyg/post/api/controller/PostController.java
+++ b/src/main/java/foiegras/ygyg/post/api/controller/PostController.java
@@ -2,6 +2,7 @@ package foiegras.ygyg.post.api.controller;
 
 
 import foiegras.ygyg.global.common.response.BaseResponse;
+import foiegras.ygyg.global.common.security.CustomUserDetails;
 import foiegras.ygyg.post.api.request.CreatePostRequest;
 import foiegras.ygyg.post.api.response.GetPostResponse;
 import foiegras.ygyg.post.application.dto.in.CreatePostInDto;
@@ -13,6 +14,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -53,8 +55,11 @@ public class PostController {
 	@Operation(summary = "소분글 상세조회", description = "소분글 상세조회", tags = { "Post" })
 	@GetMapping("/{userPostId}")
 	@SecurityRequirement(name = "Bearer Auth")
-	public BaseResponse<GetPostInDto> getPost(@PathVariable Long userPostId) {
-		GetPostInDto inDto = new GetPostInDto(userPostId);
+	public BaseResponse<GetPostInDto> getPost(@PathVariable Long userPostId, @AuthenticationPrincipal CustomUserDetails authentication) {
+		GetPostInDto inDto = GetPostInDto.builder()
+			.userPostId(userPostId)
+			.userUuid(authentication.getUserUuid())
+			.build();
 		GetPostOutDto outDto = postService.getPost(inDto);
 		GetPostResponse response = modelMapper.map(outDto, GetPostResponse.class);
 		return new BaseResponse<>(response);

--- a/src/main/java/foiegras/ygyg/post/api/response/GetPostResponse.java
+++ b/src/main/java/foiegras/ygyg/post/api/response/GetPostResponse.java
@@ -11,12 +11,9 @@ public class GetPostResponse {
 
 	private UserPostDataOutDto UserPostDataOutDto;
 	private PostDataOutDto PostDataOutDto;
-
 	private String imageUrl;
-
-	private String unit;
-	private String category;
-
-	private Boolean isActivate;
+	private String unitName;
+	private String categoryName;
+	private Boolean writerActiveState;
 
 }

--- a/src/main/java/foiegras/ygyg/post/api/response/GetPostResponse.java
+++ b/src/main/java/foiegras/ygyg/post/api/response/GetPostResponse.java
@@ -9,8 +9,8 @@ import lombok.Getter;
 @Getter
 public class GetPostResponse {
 
-	private UserPostDataOutDto getUserPostDataOutDto;
-	private PostDataOutDto getPostDataOutDto;
+	private UserPostDataOutDto UserPostDataOutDto;
+	private PostDataOutDto PostDataOutDto;
 
 	private String imageUrl;
 

--- a/src/main/java/foiegras/ygyg/post/api/response/GetPostResponse.java
+++ b/src/main/java/foiegras/ygyg/post/api/response/GetPostResponse.java
@@ -10,14 +10,12 @@ import lombok.Getter;
 public class GetPostResponse {
 
 	private UserPostDataOutDto getUserPostDataOutDto;
-
 	private PostDataOutDto getPostDataOutDto;
 
 	private String imageUrl;
 
-	private Integer unitId;
-
-	private Integer categoryId;
+	private String unit;
+	private String category;
 
 	private boolean isActivate;
 

--- a/src/main/java/foiegras/ygyg/post/api/response/GetPostResponse.java
+++ b/src/main/java/foiegras/ygyg/post/api/response/GetPostResponse.java
@@ -17,6 +17,6 @@ public class GetPostResponse {
 	private String unit;
 	private String category;
 
-	private boolean isActivate;
+	private Boolean isActivate;
 
 }

--- a/src/main/java/foiegras/ygyg/post/api/response/GetPostResponse.java
+++ b/src/main/java/foiegras/ygyg/post/api/response/GetPostResponse.java
@@ -1,0 +1,24 @@
+package foiegras.ygyg.post.api.response;
+
+
+import foiegras.ygyg.post.application.dto.in.PostDataOutDto;
+import foiegras.ygyg.post.application.dto.in.UserPostDataOutDto;
+import lombok.Getter;
+
+
+@Getter
+public class GetPostResponse {
+
+	private UserPostDataOutDto getUserPostDataOutDto;
+
+	private PostDataOutDto getPostDataOutDto;
+
+	private String imageUrl;
+
+	private Integer unitId;
+
+	private Integer categoryId;
+
+	private boolean isActivate;
+
+}

--- a/src/main/java/foiegras/ygyg/post/application/dto/in/GetPostInDto.java
+++ b/src/main/java/foiegras/ygyg/post/application/dto/in/GetPostInDto.java
@@ -2,15 +2,20 @@ package foiegras.ygyg.post.application.dto.in;
 
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.UUID;
+
 
 @Getter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class GetPostInDto {
 
 	private Long userPostId;
+	private UUID userUuid;
 
 }

--- a/src/main/java/foiegras/ygyg/post/application/dto/in/GetPostInDto.java
+++ b/src/main/java/foiegras/ygyg/post/application/dto/in/GetPostInDto.java
@@ -1,0 +1,16 @@
+package foiegras.ygyg.post.application.dto.in;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetPostInDto {
+
+	private Long userPostId;
+
+}

--- a/src/main/java/foiegras/ygyg/post/application/dto/in/GetPostOutDto.java
+++ b/src/main/java/foiegras/ygyg/post/application/dto/in/GetPostOutDto.java
@@ -1,0 +1,24 @@
+package foiegras.ygyg.post.application.dto.in;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetPostOutDto {
+
+	private UserPostDataOutDto userPostDataOutDto;
+	private PostDataOutDto postDataOutDto;
+
+	private String imageUrl;
+
+	private Integer unitId;
+	private Integer categoryId;
+
+	private boolean isActivate;
+
+}

--- a/src/main/java/foiegras/ygyg/post/application/dto/in/GetPostOutDto.java
+++ b/src/main/java/foiegras/ygyg/post/application/dto/in/GetPostOutDto.java
@@ -2,11 +2,13 @@ package foiegras.ygyg.post.application.dto.in;
 
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 
 @Getter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class GetPostOutDto {

--- a/src/main/java/foiegras/ygyg/post/application/dto/in/GetPostOutDto.java
+++ b/src/main/java/foiegras/ygyg/post/application/dto/in/GetPostOutDto.java
@@ -21,6 +21,6 @@ public class GetPostOutDto {
 	private String unit;
 	private String category;
 
-	private boolean isActivate;
+	private Boolean isActivate;
 
 }

--- a/src/main/java/foiegras/ygyg/post/application/dto/in/GetPostOutDto.java
+++ b/src/main/java/foiegras/ygyg/post/application/dto/in/GetPostOutDto.java
@@ -18,8 +18,8 @@ public class GetPostOutDto {
 
 	private String imageUrl;
 
-	private Integer unitId;
-	private Integer categoryId;
+	private String unit;
+	private String category;
 
 	private boolean isActivate;
 

--- a/src/main/java/foiegras/ygyg/post/application/dto/in/GetPostOutDto.java
+++ b/src/main/java/foiegras/ygyg/post/application/dto/in/GetPostOutDto.java
@@ -15,12 +15,9 @@ public class GetPostOutDto {
 
 	private UserPostDataOutDto userPostDataOutDto;
 	private PostDataOutDto postDataOutDto;
-
 	private String imageUrl;
-
-	private String unit;
-	private String category;
-
-	private Boolean isActivate;
+	private String unitName;
+	private String categoryName;
+	private Boolean writerActiveState;
 
 }

--- a/src/main/java/foiegras/ygyg/post/application/dto/in/PostDataOutDto.java
+++ b/src/main/java/foiegras/ygyg/post/application/dto/in/PostDataOutDto.java
@@ -1,7 +1,6 @@
 package foiegras.ygyg.post.application.dto.in;
 
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,7 +8,6 @@ import lombok.NoArgsConstructor;
 // getPostOutDto의 Post Entity 필드 컴포지션용 outDto
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor
 public class PostDataOutDto {
 
 	private String onlinePurchaseUrl;

--- a/src/main/java/foiegras/ygyg/post/application/dto/in/PostDataOutDto.java
+++ b/src/main/java/foiegras/ygyg/post/application/dto/in/PostDataOutDto.java
@@ -1,0 +1,27 @@
+package foiegras.ygyg.post.application.dto.in;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+// getPostOutDto의 Post Entity 필드 컴포지션용 outDto
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostDataOutDto {
+
+	private String onlinePurchaseUrl;
+	private Integer originalPrice;
+	private Integer amount;
+	private Integer minEngageCount;
+	private Integer maxEngageCount;
+	private Integer currentEngageCount;
+	private Double portioningPlaceLatitude;
+	private Double portioningPlaceLongitude;
+	private String description;
+	private String portioningPlaceAddress;
+	private String portioningPlaceDetailAddress;
+
+}

--- a/src/main/java/foiegras/ygyg/post/application/dto/in/UserPostDataOutDto.java
+++ b/src/main/java/foiegras/ygyg/post/application/dto/in/UserPostDataOutDto.java
@@ -1,7 +1,6 @@
 package foiegras.ygyg.post.application.dto.in;
 
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -12,7 +11,6 @@ import java.util.UUID;
 // getPostOutDto의 UserPost Entity 필드 컴포지션용 outDto
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor
 public class UserPostDataOutDto {
 
 	private Long id;

--- a/src/main/java/foiegras/ygyg/post/application/dto/in/UserPostDataOutDto.java
+++ b/src/main/java/foiegras/ygyg/post/application/dto/in/UserPostDataOutDto.java
@@ -15,6 +15,7 @@ import java.util.UUID;
 @AllArgsConstructor
 public class UserPostDataOutDto {
 
+	private Long id;
 	private UUID writerUuid;
 	private String postTitle;
 	private LocalDateTime portioningDate;

--- a/src/main/java/foiegras/ygyg/post/application/dto/in/UserPostDataOutDto.java
+++ b/src/main/java/foiegras/ygyg/post/application/dto/in/UserPostDataOutDto.java
@@ -1,0 +1,25 @@
+package foiegras.ygyg.post.application.dto.in;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+
+// getPostOutDto의 UserPost Entity 필드 컴포지션용 outDto
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserPostDataOutDto {
+
+	private UUID writerUuid;
+	private String postTitle;
+	private LocalDateTime portioningDate;
+	private Integer expectedMinimumPrice;
+	private Integer remainCount;
+	private Boolean isFullMinimum;
+
+}

--- a/src/main/java/foiegras/ygyg/post/infrastructure/jpa/ItemImageUrlJpaRepository.java
+++ b/src/main/java/foiegras/ygyg/post/infrastructure/jpa/ItemImageUrlJpaRepository.java
@@ -5,11 +5,11 @@ import foiegras.ygyg.post.infrastructure.entity.ItemImageUrlEntity;
 import foiegras.ygyg.post.infrastructure.entity.PostEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
+import java.util.List;
 
 
 public interface ItemImageUrlJpaRepository extends JpaRepository<ItemImageUrlEntity, Long> {
 
-	Optional<ItemImageUrlEntity> findByPostEntity(PostEntity postEntity);
+	List<ItemImageUrlEntity> findByPostEntity(PostEntity postEntity);
 
 }

--- a/src/main/java/foiegras/ygyg/post/infrastructure/jpa/ItemImageUrlJpaRepository.java
+++ b/src/main/java/foiegras/ygyg/post/infrastructure/jpa/ItemImageUrlJpaRepository.java
@@ -2,8 +2,14 @@ package foiegras.ygyg.post.infrastructure.jpa;
 
 
 import foiegras.ygyg.post.infrastructure.entity.ItemImageUrlEntity;
+import foiegras.ygyg.post.infrastructure.entity.PostEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
 
 
 public interface ItemImageUrlJpaRepository extends JpaRepository<ItemImageUrlEntity, Long> {
+
+	Optional<ItemImageUrlEntity> findByPostEntity(PostEntity postEntity);
+
 }

--- a/src/main/java/foiegras/ygyg/post/infrastructure/jpa/ParticipatingUsersJpaRepository.java
+++ b/src/main/java/foiegras/ygyg/post/infrastructure/jpa/ParticipatingUsersJpaRepository.java
@@ -2,8 +2,20 @@ package foiegras.ygyg.post.infrastructure.jpa;
 
 
 import foiegras.ygyg.post.infrastructure.entity.ParticipatingUsersEntity;
+import foiegras.ygyg.post.infrastructure.entity.UserPostEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
 
 
 public interface ParticipatingUsersJpaRepository extends JpaRepository<ParticipatingUsersEntity, Long> {
+
+	Optional<ParticipatingUsersEntity> findByUserPostEntity(UserPostEntity userPostEntity);
+
+	Optional<ParticipatingUsersEntity> findByUserPostEntityAndParticipatingUserUUID(
+		UserPostEntity userPostEntity,
+		UUID userUuid
+	);
+
 }

--- a/src/main/java/foiegras/ygyg/post/infrastructure/jpa/ParticipatingUsersJpaRepository.java
+++ b/src/main/java/foiegras/ygyg/post/infrastructure/jpa/ParticipatingUsersJpaRepository.java
@@ -5,13 +5,14 @@ import foiegras.ygyg.post.infrastructure.entity.ParticipatingUsersEntity;
 import foiegras.ygyg.post.infrastructure.entity.UserPostEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 
 public interface ParticipatingUsersJpaRepository extends JpaRepository<ParticipatingUsersEntity, Long> {
 
-	Optional<ParticipatingUsersEntity> findByUserPostEntity(UserPostEntity userPostEntity);
+	List<ParticipatingUsersEntity> findByUserPostEntity(UserPostEntity userPostEntity);
 
 	Optional<ParticipatingUsersEntity> findByUserPostEntityAndParticipatingUserUUID(
 		UserPostEntity userPostEntity,

--- a/src/main/java/foiegras/ygyg/post/infrastructure/jpa/PostJpaRepository.java
+++ b/src/main/java/foiegras/ygyg/post/infrastructure/jpa/PostJpaRepository.java
@@ -2,8 +2,14 @@ package foiegras.ygyg.post.infrastructure.jpa;
 
 
 import foiegras.ygyg.post.infrastructure.entity.PostEntity;
+import foiegras.ygyg.post.infrastructure.entity.UserPostEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
 
 
 public interface PostJpaRepository extends JpaRepository<PostEntity, Long> {
+
+	Optional<PostEntity> findByUserPostEntity(UserPostEntity userPostEntity);
+
 }


### PR DESCRIPTION
# 변경점 👍
게시글 상세조회 구현
 - 컨트롤러 -> 서비스엔 indto로 게시글 식별자 userPostId와 현재 유저 식별자인 UUID를 보냈습니다
 - 서비스 -> 컨트롤러에서 outdto의 전반적 구조는 게시글 생성때처럼 userPost, Post 컴포지션 적용을 했습니다.
 
# 정상 응답 스크린샷 🖼
<img width="449" alt="image" src="https://github.com/user-attachments/assets/3a3e9249-6c84-4c8d-a658-d6e2d6590a1b" />

 
 <br>
 
