### PR TITLE
refactor: PostEntity와 UserPostEntity에서 연관관계의 주인 변경

### DIFF
--- a/src/main/java/foiegras/ygyg/post/api/controller/PostController.java
+++ b/src/main/java/foiegras/ygyg/post/api/controller/PostController.java
@@ -44,9 +44,9 @@ public class PostController {
 	@Operation(summary = "소분글 생성", description = "소분글 생성", tags = { "Post" })
 	@PostMapping()
 	@SecurityRequirement(name = "Bearer Auth")
-	public BaseResponse<Void> createPost(@Valid @RequestBody CreatePostRequest request) {
-		CreatePostInDto indto = modelMapper.map(request, CreatePostInDto.class);
-		postService.createPost(indto);
+	public BaseResponse<Void> createPost(@Valid @RequestBody CreatePostRequest request, @AuthenticationPrincipal CustomUserDetails authentication) {
+		CreatePostInDto inDto = modelMapper.map(request, CreatePostInDto.class);
+		postService.createPost(inDto.toBuilder().writerUuid(authentication.getUserUuid()).build());
 		return new BaseResponse<>();
 	}
 

--- a/src/main/java/foiegras/ygyg/post/api/request/CreatePostRequest.java
+++ b/src/main/java/foiegras/ygyg/post/api/request/CreatePostRequest.java
@@ -21,6 +21,6 @@ public class CreatePostRequest {
 	private Integer unitId;
 
 	@NotNull
-	private Integer categoryId;
+	private Integer seasoningCategoryId;
 
 }

--- a/src/main/java/foiegras/ygyg/post/application/dto/in/CreatePostInDto.java
+++ b/src/main/java/foiegras/ygyg/post/application/dto/in/CreatePostInDto.java
@@ -6,9 +6,11 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.UUID;
+
 
 @Getter
-@Builder
+@Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
 public class CreatePostInDto {
@@ -24,7 +26,9 @@ public class CreatePostInDto {
 	private Integer unitId;
 
 	//## SeasoningCategoryEntity
-	private Integer categoryId;
+	private Integer seasoningCategoryId;
+
+	private UUID writerUuid;
 
 }
 

--- a/src/main/java/foiegras/ygyg/post/application/dto/in/PostDataInDto.java
+++ b/src/main/java/foiegras/ygyg/post/application/dto/in/PostDataInDto.java
@@ -33,9 +33,6 @@ public class PostDataInDto {
 	private Integer maxEngageCount;
 
 	@NotNull
-	private Integer currentEngageCount;
-
-	@NotNull
 	private Double portioningPlaceLatitude;
 
 	@NotNull

--- a/src/main/java/foiegras/ygyg/post/application/dto/in/UserPostDataInDto.java
+++ b/src/main/java/foiegras/ygyg/post/application/dto/in/UserPostDataInDto.java
@@ -10,7 +10,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
-import java.util.UUID;
 
 
 @Getter
@@ -19,18 +18,11 @@ import java.util.UUID;
 @AllArgsConstructor
 public class UserPostDataInDto {
 
-	@NotNull
-	private UUID writerUuid;
-
 	@NotBlank
 	@Size(max = 50)
 	private String postTitle;
 
 	@NotNull
 	private LocalDateTime portioningDate;
-
-	private Integer expectedMinimumPrice;
-	private Integer remainCount;
-	private Boolean isFullMinimum;
 
 }

--- a/src/main/java/foiegras/ygyg/post/infrastructure/entity/PostEntity.java
+++ b/src/main/java/foiegras/ygyg/post/infrastructure/entity/PostEntity.java
@@ -19,11 +19,6 @@ public class PostEntity {
 	@Column(name = "post_id")
 	private Long id;
 
-	// userPostId(FK)가 이 엔티티에 있어야 user_post_id로 post entity 객체를 찾을 수 있다
-	@OneToOne
-	@JoinColumn(name = "user_post_id")
-	private UserPostEntity userPostEntity;
-
 	// 상품소분단위 테이블과 다대일 매핑
 	@ManyToOne
 	@JoinColumn(name = "item_portining_unit_id")
@@ -49,7 +44,8 @@ public class PostEntity {
 	// 엔티티 변수 직접 초기화는 스키마 생성 DDL에 영향없으니 ColumnDefault나 다른 방식으로 초기화해야함
 	@Column(name = "current_engage_count", nullable = false, columnDefinition = "TINYINT")
 	@ColumnDefault("1")
-	private Integer currentEngageCount;
+	@Builder.Default
+	private Integer currentEngageCount = 1;
 
 	@Column(name = "portioning_place_latitude", nullable = false)
 	private Double portioningPlaceLatitude;

--- a/src/main/java/foiegras/ygyg/post/infrastructure/entity/UserPostEntity.java
+++ b/src/main/java/foiegras/ygyg/post/infrastructure/entity/UserPostEntity.java
@@ -22,6 +22,10 @@ public class UserPostEntity extends BaseTimeEntity {
 	@Column(name = "user_post_id")
 	private Long id;
 
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "post_id")
+	private PostEntity postEntity;
+
 	// user_post가 Many, category가 One이며 양방향 맛보기로 가보기
 	// 양방향의 경우 외래키를 가진 이 엔티티가 연관관계의 주인이다. 보통 다대일에서 다가 fk를 가짐
 	@ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/foiegras/ygyg/post/infrastructure/jpa/PostJpaRepository.java
+++ b/src/main/java/foiegras/ygyg/post/infrastructure/jpa/PostJpaRepository.java
@@ -2,14 +2,8 @@ package foiegras.ygyg.post.infrastructure.jpa;
 
 
 import foiegras.ygyg.post.infrastructure.entity.PostEntity;
-import foiegras.ygyg.post.infrastructure.entity.UserPostEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.Optional;
 
 
 public interface PostJpaRepository extends JpaRepository<PostEntity, Long> {
-
-	Optional<PostEntity> findByUserPostEntity(UserPostEntity userPostEntity);
-
 }


### PR DESCRIPTION
# Issue
- #10 

# 리팩토링 🛠
- 조회용 테이블이 UserPostEntity이므로, UserPostEntity가 PostEntity를 가지고 있어야 함. 따라서 fk의 위치를 UserPostEntity로 옮김
- 이에 따라 게시글 생성 및 조회 로직 변경

# 기타 변경사항
- 추가적으로 게시글 생성 request 및 dto에서 필요없는 컬럼 제거 및 로직 제거