### PR TITLE
feat: 소분글 참여 API 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    // retry
+    implementation 'org.springframework.retry:spring-retry'
 }
 
 tasks.named('test') {

--- a/src/main/java/foiegras/ygyg/YgygApplication.java
+++ b/src/main/java/foiegras/ygyg/YgygApplication.java
@@ -4,10 +4,12 @@ package foiegras.ygyg;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.retry.annotation.EnableRetry;
 
 
-@SpringBootApplication
+@EnableRetry
 @EnableJpaAuditing // createdAt, postedAt 자동화 위해 붙인 어노테이션
+@SpringBootApplication
 public class YgygApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/foiegras/ygyg/global/common/exception/BaseExceptionHandler.java
+++ b/src/main/java/foiegras/ygyg/global/common/exception/BaseExceptionHandler.java
@@ -12,7 +12,6 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 
-
 @RestControllerAdvice
 @Slf4j
 public class BaseExceptionHandler {
@@ -67,5 +66,7 @@ public class BaseExceptionHandler {
 		log.error("ConstraintViolationException: ", e);
 		return new ResponseEntity<>(response, response.httpStatus());
 	}
+
+	//
 
 }

--- a/src/main/java/foiegras/ygyg/global/common/response/BaseResponseStatus.java
+++ b/src/main/java/foiegras/ygyg/global/common/response/BaseResponseStatus.java
@@ -57,6 +57,9 @@ public enum BaseResponseStatus {
 	NO_EXIST_PARTICIPATING_USERS(HttpStatus.NOT_FOUND, false, 3005, "해당 게시글에 참여자 정보가 존재하지 않습니다."),
 	NO_EXIST_POST_ENTITY(HttpStatus.NOT_FOUND, false, 3006, "post가 존재하지 않습니다."),
 	NO_EXIST_ITEM_IMAGE_URL_ENTITY(HttpStatus.NOT_FOUND, false, 3007, "item_image_url이 존재하지 않습니다"),
+	CAPACITY_REACHED(HttpStatus.CONFLICT, false, 3008, "정원이 마감되었습니다"),
+	JOIN_PORTIONING_RETRY_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, false, 3009, "소분글 참여에 실패했습니다. 다시 시도해주세요"),
+	ALREADY_PARTICIPATED(HttpStatus.CONFLICT, false, 3010, "이미 참여중인 소분글입니다"),
 
 	/**
 	 * 4000: comment service error

--- a/src/main/java/foiegras/ygyg/post/api/controller/UserPostController.java
+++ b/src/main/java/foiegras/ygyg/post/api/controller/UserPostController.java
@@ -1,0 +1,44 @@
+package foiegras.ygyg.post.api.controller;
+
+
+import foiegras.ygyg.global.common.response.BaseResponse;
+import foiegras.ygyg.global.common.security.CustomUserDetails;
+import foiegras.ygyg.post.application.dto.in.JoinPortioningInDto;
+import foiegras.ygyg.post.application.facade.JoinPortioningFacade;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequestMapping("/api/v1/post")
+@RequiredArgsConstructor
+public class UserPostController {
+
+	// service
+	private final JoinPortioningFacade joinPortioningFacade;
+	// util
+	private final ModelMapper modelMapper;
+
+
+	/**
+	 * UserPostController
+	 * 1. 소분글 참여하기
+	 */
+
+	// 1. 소분글 참여하기
+	@Operation(summary = "소분글 참여하기", description = "소분글 참여하기", tags = { "Post" })
+	@PostMapping("/join/{userPostId}")
+	@SecurityRequirement(name = "Bearer Auth")
+	public BaseResponse<Void> joinPortioning(@PathVariable("userPostId") Long userPostId, @AuthenticationPrincipal CustomUserDetails authentication) {
+		joinPortioningFacade.joinPortioning(new JoinPortioningInDto(userPostId, authentication));
+		return new BaseResponse<>();
+	}
+
+}

--- a/src/main/java/foiegras/ygyg/post/application/dto/in/JoinPortioningInDto.java
+++ b/src/main/java/foiegras/ygyg/post/application/dto/in/JoinPortioningInDto.java
@@ -1,0 +1,18 @@
+package foiegras.ygyg.post.application.dto.in;
+
+
+import foiegras.ygyg.global.common.security.CustomUserDetails;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class JoinPortioningInDto {
+
+	private Long userPostId;
+	private CustomUserDetails authentication;
+
+}

--- a/src/main/java/foiegras/ygyg/post/application/facade/JoinPortioningFacade.java
+++ b/src/main/java/foiegras/ygyg/post/application/facade/JoinPortioningFacade.java
@@ -1,0 +1,88 @@
+package foiegras.ygyg.post.application.facade;
+
+
+import foiegras.ygyg.global.common.exception.BaseException;
+import foiegras.ygyg.global.common.response.BaseResponseStatus;
+import foiegras.ygyg.post.application.dto.in.JoinPortioningInDto;
+import foiegras.ygyg.post.application.service.ParticipatingUserService;
+import foiegras.ygyg.post.application.service.PostService;
+import foiegras.ygyg.post.application.service.UserPostService;
+import foiegras.ygyg.post.infrastructure.entity.PostEntity;
+import foiegras.ygyg.post.infrastructure.entity.UserPostEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class JoinPortioningFacade {
+
+	// value
+	private static final String JOIN = "join";
+	// service
+	private final PostService postService;
+	private final UserPostService userPostService;
+	private final ParticipatingUserService participatingUserService;
+
+
+	/**
+	 * ParticipatePortioningFacade
+	 * - 소분글 참여하기
+	 * 1. 참여 가능 남은 인원수 확인
+	 * 2-1 참여 가능하다면 소분글 참여
+	 * 2-2. 불가능하다면 exception
+	 */
+
+	// 소분글 참여하기
+	@Retryable(
+		retryFor = { OptimisticLockingFailureException.class }, // 재시도 대상 exception
+		maxAttempts = 3, // 재시도 횟수
+		backoff = @Backoff(delay = 500), // 재시도 딜레이
+		recover = "joinPortioningRecover" // 재시도 실패시 호출할 메소드
+	)
+	public void joinPortioning(JoinPortioningInDto joinPortioningInDto) {
+		// 참여자 UUID
+		UUID participantUuid = joinPortioningInDto.getAuthentication().getUserUuid();
+		// 소분글 조회
+		UserPostEntity userPost = userPostService.getUserPostById(joinPortioningInDto.getUserPostId());
+		// 본인 참여 여부 확인 -> 이미 참여중이라면 exception
+		if (participatingUserService.checkParticipatedState(participantUuid, userPost)) {
+			throw new BaseException(BaseResponseStatus.ALREADY_PARTICIPATED);
+		}
+		// 참여 가능 인원수가 0보다 큰 경우(참여 가능한 경우) 참여
+		if (userPost.getRemainCount() > 0) {
+			// 현재 참여자 수 증가
+			PostEntity updatedPost = postService.updateCurrentEngageCount(userPost.getPostEntity(), JOIN);
+			// 소분글 참여
+			UserPostEntity updatedUserPost = userPostService.joinPortioning(userPost, updatedPost.getCurrentEngageCount(), updatedPost.getMinEngageCount());
+			// 소분글 참여자 생성
+			participatingUserService.createParticipatingUser(participantUuid, updatedUserPost);
+		}
+		// 참여 가능 인원수가 0인 경우(참여 불가능한 경우) throw exception
+		else {
+			throw new BaseException(BaseResponseStatus.CAPACITY_REACHED);
+		}
+	}
+
+
+	/**
+	 * Recover: retry 실패시 예외처리
+	 */
+	@Recover
+	private void joinPortioningRecover(RuntimeException e, JoinPortioningInDto joinPortioningInDto) {
+		if (e instanceof OptimisticLockingFailureException) {
+			throw new BaseException(BaseResponseStatus.JOIN_PORTIONING_RETRY_FAILED);
+		} else if (e instanceof BaseException) {
+			throw (BaseException) e;
+		}
+	}
+
+}

--- a/src/main/java/foiegras/ygyg/post/application/service/ParticipatingUserService.java
+++ b/src/main/java/foiegras/ygyg/post/application/service/ParticipatingUserService.java
@@ -1,0 +1,39 @@
+package foiegras.ygyg.post.application.service;
+
+
+import foiegras.ygyg.post.infrastructure.entity.ParticipatingUsersEntity;
+import foiegras.ygyg.post.infrastructure.entity.UserPostEntity;
+import foiegras.ygyg.post.infrastructure.jpa.ParticipatingUsersJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ParticipatingUserService {
+
+	// repository
+	private final ParticipatingUsersJpaRepository participatingUsersJpaRepository;
+
+
+	/**
+	 * ParticipatingUserService
+	 * 1. 참여자 생성
+	 * 2. 참여 상태 확인
+	 */
+
+	// 1. 참여자 생성
+	public ParticipatingUsersEntity createParticipatingUser(UUID participantUuid, UserPostEntity userPost) {
+		return participatingUsersJpaRepository.save(ParticipatingUsersEntity.createNew(participantUuid, userPost));
+	}
+
+
+	public boolean checkParticipatedState(UUID participantUuid, UserPostEntity userPost) {
+		return participatingUsersJpaRepository.existsByParticipatingUserUUIDAndUserPostEntity(participantUuid, userPost);
+	}
+
+}

--- a/src/main/java/foiegras/ygyg/post/application/service/PostService.java
+++ b/src/main/java/foiegras/ygyg/post/application/service/PostService.java
@@ -129,6 +129,12 @@ public class PostService {
 
 	}
 
+
+	// 5. 현재 참여인원 수정
+	public PostEntity updateCurrentEngageCount(PostEntity postEntity, String type) {
+		return postEntity.updateCurrentEngageCount(type);
+	}
+
 }
 
 

--- a/src/main/java/foiegras/ygyg/post/application/service/UserPostService.java
+++ b/src/main/java/foiegras/ygyg/post/application/service/UserPostService.java
@@ -1,0 +1,63 @@
+package foiegras.ygyg.post.application.service;
+
+
+import foiegras.ygyg.global.common.exception.BaseException;
+import foiegras.ygyg.global.common.response.BaseResponseStatus;
+import foiegras.ygyg.post.infrastructure.entity.UserPostEntity;
+import foiegras.ygyg.post.infrastructure.jpa.UserPostJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UserPostService {
+
+	// value
+	private static final String JOIN = "join";
+	private static final String CANCEL = "cancel";
+	// repository
+	private final UserPostJpaRepository userPostJpaRepository;
+	// util
+	private final ModelMapper modelMapper;
+
+
+	/**
+	 * UserPostService
+	 * 1. id로 UserPost 조회
+	 * 2. 소분글 참여하기
+	 * 3. 참여 가능 남은 인원수 업데이트
+	 * 4. 최소 참여 인원 달성 여부 업데이트
+	 */
+
+	// 1. id로 UserPost 조회
+	public UserPostEntity getUserPostById(Long userPostId) {
+		return userPostJpaRepository.findById(userPostId)
+			.orElseThrow(() -> new BaseException(BaseResponseStatus.NO_EXIST_POST));
+	}
+
+
+	// 2. 소분글 참여하기
+	public UserPostEntity joinPortioning(UserPostEntity userPost, Integer currentEngageCount, Integer minEngageCount) {
+		// 참여 가능 남은 인원수 업데이트
+		this.updateRemainCount(userPost, JOIN);
+		// 최소 참여 인원 달성 여부 업데이트
+		return this.updateIsFullMinimum(userPost, currentEngageCount, minEngageCount);
+	}
+
+
+	// 3. 참여 가능 남은 인원수 업데이트
+	public UserPostEntity updateRemainCount(UserPostEntity userPost, String type) {
+		return userPost.updateRemainCount(type);
+	}
+
+
+	// 4. 최소 참여 인원 달성 여부 업데이트
+	public UserPostEntity updateIsFullMinimum(UserPostEntity userPost, Integer currentEngageCount, Integer minEngageCount) {
+		return userPost.updateIsFullMinimum(currentEngageCount, minEngageCount);
+	}
+
+}

--- a/src/main/java/foiegras/ygyg/post/infrastructure/entity/ParticipatingUsersEntity.java
+++ b/src/main/java/foiegras/ygyg/post/infrastructure/entity/ParticipatingUsersEntity.java
@@ -24,8 +24,21 @@ public class ParticipatingUsersEntity {
 	private UUID participatingUserUUID;
 
 	// 다대일 단방향에서 fk는 多인 참여자 엔티티가 갖게 된다
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_post_id")
 	private UserPostEntity userPostEntity;
+
+
+	/**
+	 * 생성자
+	 * - createNew: 참여자 UUID, 참여자가 참여한 게시글
+	 */
+
+	public static ParticipatingUsersEntity createNew(UUID participatingUserUUID, UserPostEntity userPostEntity) {
+		return ParticipatingUsersEntity.builder()
+			.participatingUserUUID(participatingUserUUID)
+			.userPostEntity(userPostEntity)
+			.build();
+	}
 
 }

--- a/src/main/java/foiegras/ygyg/post/infrastructure/entity/PostEntity.java
+++ b/src/main/java/foiegras/ygyg/post/infrastructure/entity/PostEntity.java
@@ -14,6 +14,10 @@ import org.hibernate.annotations.ColumnDefault;
 @Table(name = "post")
 public class PostEntity {
 
+	// value
+	private final static String JOIN = "join";
+	private final static String CANCEL = "cancel";
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "post_id")
@@ -62,5 +66,20 @@ public class PostEntity {
 
 	@Column(name = "portioning_place_detail_address", length = 100, nullable = false)
 	private String portioningPlaceDetailAddress;
+
+
+	/**
+	 * PostEntity
+	 * 1. 현재 참여 인원수 업데이트
+	 */
+
+	public PostEntity updateCurrentEngageCount(String type) {
+		if (type.equals(JOIN)) {
+			this.currentEngageCount++;
+		} else if (type.equals(CANCEL)) {
+			this.currentEngageCount--;
+		}
+		return this;
+	}
 
 }

--- a/src/main/java/foiegras/ygyg/post/infrastructure/entity/UserPostEntity.java
+++ b/src/main/java/foiegras/ygyg/post/infrastructure/entity/UserPostEntity.java
@@ -17,10 +17,18 @@ import java.util.UUID;
 @Table(name = "user_post")
 public class UserPostEntity extends BaseTimeEntity {
 
+	// value
+	private final static String JOIN = "join";
+	private final static String CANCEL = "cancel";
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "user_post_id")
 	private Long id;
+
+	@Version
+	@Column(name = "version", nullable = false)
+	private Long version;
 
 	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "post_id")
@@ -57,5 +65,31 @@ public class UserPostEntity extends BaseTimeEntity {
 
 	@Column(name = "portioning_date", nullable = false)
 	private LocalDateTime portioningDate;
+
+
+	/**
+	 * UserPostEntity
+	 * 1. 참여 가능 남은 인원수 업데이트
+	 * 2. 최소 참여 인원 달성 여부 업데이트
+	 */
+
+	// 1. 참여 가능 남은 인원수 업데이트
+	public UserPostEntity updateRemainCount(String type) {
+		if (type.equals(JOIN)) {
+			this.remainCount--;
+		} else if (type.equals(CANCEL)) {
+			this.remainCount++;
+		}
+		return this;
+	}
+
+
+	// 2. 최소 참여 인원 달성 여부 업데이트
+	public UserPostEntity updateIsFullMinimum(Integer currentEngageCount, Integer minEngageCount) {
+		if (currentEngageCount >= minEngageCount) {
+			this.isFullMinimum = true;
+		}
+		return this;
+	}
 
 }

--- a/src/main/java/foiegras/ygyg/post/infrastructure/jpa/ParticipatingUsersJpaRepository.java
+++ b/src/main/java/foiegras/ygyg/post/infrastructure/jpa/ParticipatingUsersJpaRepository.java
@@ -19,4 +19,7 @@ public interface ParticipatingUsersJpaRepository extends JpaRepository<Participa
 		UUID userUuid
 	);
 
+	// UserUuid와 UserPostEntity로 참여자 존재 여부 확인
+	boolean existsByParticipatingUserUUIDAndUserPostEntity(UUID participantUuid, UserPostEntity userPost);
+
 }


### PR DESCRIPTION
# Issue
- #10 

# 변경점 👍
- 소분글 참여 API 개발
- 필요한 Controller, Service, Facade, Dto 생성
- Retry 사용을 위한 의존성 추가
- 소분글 참여시 Post의 currentEngageCount 증가, UserPost의 remainCount 감소, 최소 참여 인원 달성시에는 isFullMinimum 업데이트
- 낙관적락을 사용하기 위해 PostEntity에 @Version 사용