### PR TITLE
feat: 소분글 수정, 삭제 기능 구현

### DIFF
--- a/src/main/java/foiegras/ygyg/post/api/controller/PostController.java
+++ b/src/main/java/foiegras/ygyg/post/api/controller/PostController.java
@@ -73,9 +73,11 @@ public class PostController {
 	@Operation(summary = "소분글 수정", description = "소분글 수정", tags = { "Post" })
 	@PutMapping("/{userPostId}")
 	@SecurityRequirement(name = "Bearer Auth")
-	public BaseResponse<Void> updatePost(@PathVariable Long userPostId, @RequestBody UpdatePostRequest request) {
+	public BaseResponse<Void> updatePost(@PathVariable Long userPostId, @RequestBody UpdatePostRequest request, @AuthenticationPrincipal CustomUserDetails auth) {
 		UpdatePostInDto inDto = modelMapper.map(request, UpdatePostInDto.class);
-		inDto = inDto.toBuilder().userPostId(userPostId).build();
+		inDto = inDto.toBuilder()
+			.userPostId(userPostId)
+			.userUuid(auth.getUserUuid()).build();
 		postService.updatePost(inDto);
 		return new BaseResponse<>();
 	}
@@ -85,10 +87,10 @@ public class PostController {
 	@Operation(summary = "소분글 삭제", description = "소분글 삭제", tags = { "Post" })
 	@DeleteMapping("/{userPostId}")
 	@SecurityRequirement(name = "Bearer Auth")
-	public BaseResponse<Void> deletePost(@PathVariable Long userPostId) {
+	public BaseResponse<Void> deletePost(@PathVariable Long userPostId, @AuthenticationPrincipal CustomUserDetails auth) {
 		DeletePostInDto inDto = DeletePostInDto.builder()
 			.userPostId(userPostId)
-			.build();
+			.userUuid(auth.getUserUuid()).build();
 		postService.deletePost(inDto);
 		return new BaseResponse<>();
 	}

--- a/src/main/java/foiegras/ygyg/post/api/controller/PostController.java
+++ b/src/main/java/foiegras/ygyg/post/api/controller/PostController.java
@@ -4,9 +4,12 @@ package foiegras.ygyg.post.api.controller;
 import foiegras.ygyg.global.common.response.BaseResponse;
 import foiegras.ygyg.global.common.security.CustomUserDetails;
 import foiegras.ygyg.post.api.request.CreatePostRequest;
+import foiegras.ygyg.post.api.request.UpdatePostRequest;
 import foiegras.ygyg.post.api.response.GetPostResponse;
 import foiegras.ygyg.post.application.dto.post.in.CreatePostInDto;
+import foiegras.ygyg.post.application.dto.post.in.DeletePostInDto;
 import foiegras.ygyg.post.application.dto.post.in.GetPostInDto;
+import foiegras.ygyg.post.application.dto.post.in.UpdatePostInDto;
 import foiegras.ygyg.post.application.dto.post.out.GetPostOutDto;
 import foiegras.ygyg.post.application.service.PostService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -63,6 +66,31 @@ public class PostController {
 		GetPostOutDto outDto = postService.getPost(inDto);
 		GetPostResponse response = modelMapper.map(outDto, GetPostResponse.class);
 		return new BaseResponse<>(response);
+	}
+
+
+	// 3. 소분글 수정
+	@Operation(summary = "소분글 수정", description = "소분글 수정", tags = { "Post" })
+	@PutMapping("/{userPostId}")
+	@SecurityRequirement(name = "Bearer Auth")
+	public BaseResponse<Void> updatePost(@PathVariable Long userPostId, @RequestBody UpdatePostRequest request) {
+		UpdatePostInDto inDto = modelMapper.map(request, UpdatePostInDto.class);
+		inDto = inDto.toBuilder().userPostId(userPostId).build();
+		postService.updatePost(inDto);
+		return new BaseResponse<>();
+	}
+
+
+	// 4. 소분글 삭제
+	@Operation(summary = "소분글 삭제", description = "소분글 삭제", tags = { "Post" })
+	@DeleteMapping("/{userPostId}")
+	@SecurityRequirement(name = "Bearer Auth")
+	public BaseResponse<Void> deletePost(@PathVariable Long userPostId) {
+		DeletePostInDto inDto = DeletePostInDto.builder()
+			.userPostId(userPostId)
+			.build();
+		postService.deletePost(inDto);
+		return new BaseResponse<>();
 	}
 
 }

--- a/src/main/java/foiegras/ygyg/post/api/request/UpdatePostRequest.java
+++ b/src/main/java/foiegras/ygyg/post/api/request/UpdatePostRequest.java
@@ -1,0 +1,22 @@
+package foiegras.ygyg.post.api.request;
+
+
+import foiegras.ygyg.post.application.dto.post.in.PostDataInDto;
+import foiegras.ygyg.post.application.dto.userpost.in.UserPostDataInDto;
+import lombok.Getter;
+
+
+@Getter
+public class UpdatePostRequest {
+
+	private UserPostDataInDto userPostDataInDto;
+
+	private PostDataInDto postDataInDto;
+
+	private String imageUrl;
+
+	private Integer unitId;
+
+	private Integer seasoningCategoryId;
+
+}

--- a/src/main/java/foiegras/ygyg/post/api/response/GetPostResponse.java
+++ b/src/main/java/foiegras/ygyg/post/api/response/GetPostResponse.java
@@ -14,6 +14,6 @@ public class GetPostResponse {
 	private String imageUrl;
 	private String unitName;
 	private String categoryName;
-	private Boolean writerActiveState;
+	private Boolean userParticipatingIn;
 
 }

--- a/src/main/java/foiegras/ygyg/post/application/dto/post/in/DeletePostInDto.java
+++ b/src/main/java/foiegras/ygyg/post/application/dto/post/in/DeletePostInDto.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.UUID;
+
 
 @Getter
 @Builder
@@ -15,6 +17,9 @@ import lombok.NoArgsConstructor;
 public class DeletePostInDto {
 
 	@NotNull
-	Long userPostId;
+	private Long userPostId;
+
+	@NotNull
+	private UUID userUuid;
 
 }

--- a/src/main/java/foiegras/ygyg/post/application/dto/post/in/DeletePostInDto.java
+++ b/src/main/java/foiegras/ygyg/post/application/dto/post/in/DeletePostInDto.java
@@ -1,0 +1,20 @@
+package foiegras.ygyg.post.application.dto.post.in;
+
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DeletePostInDto {
+
+	@NotNull
+	Long userPostId;
+
+}

--- a/src/main/java/foiegras/ygyg/post/application/dto/post/in/UpdatePostInDto.java
+++ b/src/main/java/foiegras/ygyg/post/application/dto/post/in/UpdatePostInDto.java
@@ -1,0 +1,27 @@
+package foiegras.ygyg.post.application.dto.post.in;
+
+
+import foiegras.ygyg.post.application.dto.userpost.in.UserPostDataInDto;
+import lombok.*;
+
+
+@Getter
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class UpdatePostInDto {
+
+	Long userPostId;
+
+	private UserPostDataInDto userPostDataInDto;
+
+	private PostDataInDto postDataInDto;
+
+	private String imageUrl;
+
+	private Integer unitId;
+
+	private Integer seasoningCategoryId;
+
+}

--- a/src/main/java/foiegras/ygyg/post/application/dto/post/in/UpdatePostInDto.java
+++ b/src/main/java/foiegras/ygyg/post/application/dto/post/in/UpdatePostInDto.java
@@ -4,6 +4,8 @@ package foiegras.ygyg.post.application.dto.post.in;
 import foiegras.ygyg.post.application.dto.userpost.in.UserPostDataInDto;
 import lombok.*;
 
+import java.util.UUID;
+
 
 @Getter
 @Builder(toBuilder = true)
@@ -12,7 +14,9 @@ import lombok.*;
 @ToString
 public class UpdatePostInDto {
 
-	Long userPostId;
+	private Long userPostId;
+	
+	private UUID userUuid;
 
 	private UserPostDataInDto userPostDataInDto;
 

--- a/src/main/java/foiegras/ygyg/post/application/dto/post/out/GetPostOutDto.java
+++ b/src/main/java/foiegras/ygyg/post/application/dto/post/out/GetPostOutDto.java
@@ -19,6 +19,6 @@ public class GetPostOutDto {
 	private String imageUrl;
 	private String unitName;
 	private String categoryName;
-	private Boolean writerActiveState;
+	private Boolean userParticipatingIn;
 
 }

--- a/src/main/java/foiegras/ygyg/post/application/dto/userpost/out/UserPostDataOutDto.java
+++ b/src/main/java/foiegras/ygyg/post/application/dto/userpost/out/UserPostDataOutDto.java
@@ -1,6 +1,8 @@
 package foiegras.ygyg.post.application.dto.userpost.out;
 
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -11,6 +13,8 @@ import java.util.UUID;
 // getPostOutDto의 UserPost Entity 필드 컴포지션용 outDto
 @Getter
 @NoArgsConstructor
+@Builder(toBuilder = true)
+@AllArgsConstructor
 public class UserPostDataOutDto {
 
 	private Long id;

--- a/src/main/java/foiegras/ygyg/post/infrastructure/entity/ItemImageUrlEntity.java
+++ b/src/main/java/foiegras/ygyg/post/infrastructure/entity/ItemImageUrlEntity.java
@@ -7,7 +7,7 @@ import lombok.*;
 
 @Entity
 @Getter
-@Builder
+@Builder(toBuilder = true)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "item_image_url")

--- a/src/main/java/foiegras/ygyg/post/infrastructure/jpa/post/ItemImageUrlJpaRepository.java
+++ b/src/main/java/foiegras/ygyg/post/infrastructure/jpa/post/ItemImageUrlJpaRepository.java
@@ -12,4 +12,6 @@ public interface ItemImageUrlJpaRepository extends JpaRepository<ItemImageUrlEnt
 
 	List<ItemImageUrlEntity> findByPostEntity(PostEntity postEntity);
 
+	void deleteByPostEntity(PostEntity postEntity);
+
 }

--- a/src/main/java/foiegras/ygyg/post/infrastructure/jpa/post/ParticipatingUsersJpaRepository.java
+++ b/src/main/java/foiegras/ygyg/post/infrastructure/jpa/post/ParticipatingUsersJpaRepository.java
@@ -25,4 +25,6 @@ public interface ParticipatingUsersJpaRepository extends JpaRepository<Participa
 	// UserUuid로 참여자 삭제
 	void deleteAllByParticipatingUserUUID(UUID userUuid);
 
+	void deleteByUserPostEntity(UserPostEntity userPostEntity);
+
 }


### PR DESCRIPTION
# 변경점 👍
수정, 삭제 기능을 구현했습니다.
1. 수정은 userPostId 입력으로 특정 소분글 관련 엔티티를 모두 가져와 tobuilder로 다시 save하는 방식으로 구현했습니다.
2. 삭제는 간단하게 엔티티들을 모두 가져와 삭제했습니다.
 
# 리팩토링 🛠
추가로 상세조회 api 쪽에서 소분글 게시자가 탈퇴유저시 응답단의 writerUuid를 null로 바꾸는 로직을 추가했습니다.
 

 
 <br>
 
