### PR TITLE
feat: 타입별 내 소분글 목록 조회 API 개발

### DIFF
--- a/src/main/java/foiegras/ygyg/global/common/querydsl/CursorBasePaginationProperty.java
+++ b/src/main/java/foiegras/ygyg/global/common/querydsl/CursorBasePaginationProperty.java
@@ -1,0 +1,8 @@
+package foiegras.ygyg.global.common.querydsl;
+
+
+public interface CursorBasePaginationProperty<T> {
+
+	T findCursor();
+
+}

--- a/src/main/java/foiegras/ygyg/global/common/querydsl/PostDomainBooleanExpression.java
+++ b/src/main/java/foiegras/ygyg/global/common/querydsl/PostDomainBooleanExpression.java
@@ -1,0 +1,62 @@
+package foiegras.ygyg.global.common.querydsl;
+
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import foiegras.ygyg.post.infrastructure.entity.QItemImageUrlEntity;
+import foiegras.ygyg.post.infrastructure.entity.QParticipatingUsersEntity;
+import foiegras.ygyg.post.infrastructure.entity.QPostEntity;
+import foiegras.ygyg.post.infrastructure.entity.QUserPostEntity;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+
+@Component
+public class PostDomainBooleanExpression {
+
+	// query dsl value
+	private final static QUserPostEntity userPostEntity = QUserPostEntity.userPostEntity;
+	private final static QParticipatingUsersEntity participatingUsersEntity = QParticipatingUsersEntity.participatingUsersEntity;
+	private final static QPostEntity postEntity = QPostEntity.postEntity;
+	private final static QItemImageUrlEntity itemImageUrlEntity = QItemImageUrlEntity.itemImageUrlEntity;
+	// static value
+	private final static String ASC = "asc";
+	private final static String DESC = "desc";
+	private final static String WRITTEN = "written";
+	private final static String JOIN = "join";
+	private final static String COMPLETE = "complete";
+
+
+	/**
+	 * Post 도메인의 BooleanExpressions
+	 * 1. cursor로 다음 userPost 조회
+	 * 2. 타입별 userPost 조회
+	 */
+
+	// 1. cursor로 다음 userPost 조회
+	public BooleanExpression getNextUserPost(Long lastCursor, String order) {
+		// 첫 페이지인 경우 -> lastCursor가 없음
+		if (lastCursor == null) {
+			return null;
+		}
+		// 두 번째 페이지부터 -> lastCursor 이후의 Post를 조회
+		return order.equals(ASC) ? userPostEntity.id.gt(lastCursor) : userPostEntity.id.lt(lastCursor);
+	}
+
+
+	// 2. 타입별 userPost 조회: written(내가 작성), join(내가 참여), complete(소분 완료)
+	public BooleanExpression selectType(String type, UUID userUuid, LocalDateTime currentTime) {
+		BooleanExpression written = userPostEntity.writerUuid.eq(userUuid);
+		BooleanExpression join = written.or(participatingUsersEntity.participatingUserUUID.eq(userUuid));
+		BooleanExpression beforeComplete = userPostEntity.portioningDate.gt(currentTime);
+		BooleanExpression afterComplete = userPostEntity.portioningDate.lt(currentTime);
+		return switch (type) {
+			case WRITTEN -> written.and(beforeComplete);
+			case JOIN -> join.and(beforeComplete);
+			case COMPLETE -> join.and(afterComplete);
+			default -> null;
+		};
+	}
+
+}

--- a/src/main/java/foiegras/ygyg/global/common/querydsl/QueryDslService.java
+++ b/src/main/java/foiegras/ygyg/global/common/querydsl/QueryDslService.java
@@ -1,0 +1,40 @@
+package foiegras.ygyg.global.common.querydsl;
+
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.util.Pair;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+
+@Service
+public class QueryDslService {
+
+	/**
+	 * Cursor
+	 * 1. content에서 마지막 cursor 가져오기
+	 * 2. 다음 페이지 존재 여부 확인
+	 */
+
+	// 1. content에서 마지막 cursor 가져오기
+	public <T extends CursorBasePaginationProperty<S>, S> S getLastCursor(List<T> content) {
+		S lastCursorId = null;
+		if (!content.isEmpty()) {
+			lastCursorId = content.get(content.size() - 1).findCursor();
+		}
+		return lastCursorId;
+	}
+
+
+	// 2. 다음 페이지 존재 여부 확인
+	public <T> Pair<Boolean, List<T>> getHasNext(Pageable pageable, List<T> content) {
+		boolean hasNext = false;
+		if (content.size() > pageable.getPageSize()) {
+			content.remove(pageable.getPageSize());
+			hasNext = true;
+		}
+		return Pair.of(hasNext, content);
+	}
+
+}

--- a/src/main/java/foiegras/ygyg/post/api/controller/UserPostController.java
+++ b/src/main/java/foiegras/ygyg/post/api/controller/UserPostController.java
@@ -3,10 +3,14 @@ package foiegras.ygyg.post.api.controller;
 
 import foiegras.ygyg.global.common.response.BaseResponse;
 import foiegras.ygyg.global.common.security.CustomUserDetails;
+import foiegras.ygyg.post.api.request.GetMyPostListRequest;
+import foiegras.ygyg.post.api.response.GetUserPostListByCursorResponse;
 import foiegras.ygyg.post.api.response.GetUserPostListResponse;
+import foiegras.ygyg.post.application.dto.userpost.in.GetMyPostListInDto;
 import foiegras.ygyg.post.application.dto.userpost.in.GetUserPostListByCategoryInDto;
 import foiegras.ygyg.post.application.dto.userpost.in.GetUserPostListInDto;
 import foiegras.ygyg.post.application.dto.userpost.in.JoinPortioningInDto;
+import foiegras.ygyg.post.application.dto.userpost.out.GetUserPostListByCursorOutDto;
 import foiegras.ygyg.post.application.dto.userpost.out.GetUserPostListOutDto;
 import foiegras.ygyg.post.application.facade.JoinPortioningFacade;
 import foiegras.ygyg.post.application.service.UserPostService;
@@ -18,6 +22,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
 
 
 @RestController
@@ -37,6 +43,7 @@ public class UserPostController {
 	 * 1. 소분글 참여하기
 	 * 2. 소분글 전체목록 조회
 	 * 3. 소분글 카테고리별 목록 조회
+	 * 4. 타입별 소분글 목록 조회
 	 */
 
 	// 1. 소분글 참여하기
@@ -67,6 +74,23 @@ public class UserPostController {
 		GetUserPostListOutDto outDto = userPostService.getUserPostListByCategory(new GetUserPostListByCategoryInDto(categoryId, sortBy, pageable));
 		GetUserPostListResponse response = modelMapper.map(outDto, GetUserPostListResponse.class);
 		return new BaseResponse<>(response);
+	}
+
+
+	// 4. 타입별 내 소분글 목록 조회
+	@Operation(summary = "타입별 내 소분글 목록 조회", description = "type: written(내가 작성), join(내가 참여), complete(소분 완료)", tags = { "Post" })
+	@GetMapping("/my/list")
+	@SecurityRequirement(name = "Bearer Auth")
+	public BaseResponse<GetUserPostListByCursorResponse> getMyPostListByType(GetMyPostListRequest request, Pageable pageable, @AuthenticationPrincipal CustomUserDetails authentication) {
+		GetMyPostListInDto inDto = modelMapper.map(request, GetMyPostListInDto.class);
+		inDto = inDto.toBuilder()
+			.pageable(pageable)
+			.userUuid(authentication.getUserUuid())
+			.currentTime(LocalDateTime.now())
+			.build();
+		GetUserPostListByCursorOutDto outDto = userPostService.getMyPostListByType(inDto);
+		GetUserPostListByCursorResponse response = modelMapper.map(outDto, GetUserPostListByCursorResponse.class);
+		return new BaseResponse<>(response.toBuilder().myPost(outDto.getContent()).build());
 	}
 
 }

--- a/src/main/java/foiegras/ygyg/post/api/request/GetMyPostListRequest.java
+++ b/src/main/java/foiegras/ygyg/post/api/request/GetMyPostListRequest.java
@@ -1,0 +1,16 @@
+package foiegras.ygyg.post.api.request;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+
+@Getter
+@AllArgsConstructor
+public class GetMyPostListRequest {
+
+	private String type;
+	private Long lastCursor;
+	private String order;
+
+}

--- a/src/main/java/foiegras/ygyg/post/api/response/GetUserPostListByCursorResponse.java
+++ b/src/main/java/foiegras/ygyg/post/api/response/GetUserPostListByCursorResponse.java
@@ -1,0 +1,23 @@
+package foiegras.ygyg.post.api.response;
+
+
+import foiegras.ygyg.post.application.dto.userpost.out.UserPostItemDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+
+@Getter
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetUserPostListByCursorResponse {
+
+	private List<UserPostItemDto> myPost;
+	private Long lastCursor;
+	private Boolean hasNext;
+
+}

--- a/src/main/java/foiegras/ygyg/post/application/dto/userpost/in/GetMyPostListInDto.java
+++ b/src/main/java/foiegras/ygyg/post/application/dto/userpost/in/GetMyPostListInDto.java
@@ -1,0 +1,27 @@
+package foiegras.ygyg.post.application.dto.userpost.in;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+
+@Getter
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetMyPostListInDto {
+
+	private String type;
+	private Long lastCursor;
+	private Pageable pageable;
+	private String order;
+	private UUID userUuid;
+	private LocalDateTime currentTime;
+
+}

--- a/src/main/java/foiegras/ygyg/post/application/dto/userpost/out/GetUserPostListByCursorOutDto.java
+++ b/src/main/java/foiegras/ygyg/post/application/dto/userpost/out/GetUserPostListByCursorOutDto.java
@@ -1,0 +1,24 @@
+package foiegras.ygyg.post.application.dto.userpost.out;
+
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.SliceImpl;
+
+import java.util.List;
+
+
+@Getter
+public class GetUserPostListByCursorOutDto extends SliceImpl<UserPostItemDto> {
+
+	private Long lastCursor;
+
+
+	@Builder
+	public GetUserPostListByCursorOutDto(List<UserPostItemDto> content, Pageable pageable, boolean hasNext, Long lastCursor) {
+		super(content, pageable, hasNext);
+		this.lastCursor = lastCursor;
+	}
+
+}

--- a/src/main/java/foiegras/ygyg/post/application/dto/userpost/out/UserPostItemDto.java
+++ b/src/main/java/foiegras/ygyg/post/application/dto/userpost/out/UserPostItemDto.java
@@ -1,7 +1,8 @@
 package foiegras.ygyg.post.application.dto.userpost.out;
 
 
-import lombok.AllArgsConstructor;
+import com.querydsl.core.annotations.QueryProjection;
+import foiegras.ygyg.global.common.querydsl.CursorBasePaginationProperty;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,8 +13,7 @@ import java.time.LocalDateTime;
 @Getter
 @Builder
 @NoArgsConstructor
-@AllArgsConstructor
-public class UserPostItemDto {
+public class UserPostItemDto implements CursorBasePaginationProperty<Long> {
 
 	private Long userPostId;
 	private String postTitle;
@@ -23,5 +23,25 @@ public class UserPostItemDto {
 	private Integer minEngageCount;
 	private Integer maxEngageCount;
 	private Integer currentEngageCount;
+
+
+	@QueryProjection
+	public UserPostItemDto(Long userPostId, String postTitle, String imageUrl, LocalDateTime portioningDate, Integer originalPrice, Integer minEngageCount, Integer maxEngageCount,
+		Integer currentEngageCount) {
+		this.userPostId = userPostId;
+		this.postTitle = postTitle;
+		this.imageUrl = imageUrl;
+		this.portioningDate = portioningDate;
+		this.originalPrice = originalPrice;
+		this.minEngageCount = minEngageCount;
+		this.maxEngageCount = maxEngageCount;
+		this.currentEngageCount = currentEngageCount;
+	}
+
+
+	@Override
+	public Long findCursor() {
+		return userPostId;
+	}
 
 }

--- a/src/main/java/foiegras/ygyg/post/application/dto/userpost/out/UserPostListQueryDataByCursorOutDto.java
+++ b/src/main/java/foiegras/ygyg/post/application/dto/userpost/out/UserPostListQueryDataByCursorOutDto.java
@@ -1,0 +1,22 @@
+package foiegras.ygyg.post.application.dto.userpost.out;
+
+
+import lombok.Getter;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.SliceImpl;
+
+import java.util.List;
+
+
+@Getter
+public class UserPostListQueryDataByCursorOutDto extends SliceImpl<UserPostItemDto> {
+
+	private Long lastCursor;
+
+
+	public UserPostListQueryDataByCursorOutDto(List<UserPostItemDto> content, Pageable pageable, boolean hasNext, Long lastCursor) {
+		super(content, pageable, hasNext);
+		this.lastCursor = lastCursor;
+	}
+
+}

--- a/src/main/java/foiegras/ygyg/post/application/service/UserPostService.java
+++ b/src/main/java/foiegras/ygyg/post/application/service/UserPostService.java
@@ -3,11 +3,10 @@ package foiegras.ygyg.post.application.service;
 
 import foiegras.ygyg.global.common.exception.BaseException;
 import foiegras.ygyg.global.common.response.BaseResponseStatus;
+import foiegras.ygyg.post.application.dto.userpost.in.GetMyPostListInDto;
 import foiegras.ygyg.post.application.dto.userpost.in.GetUserPostListByCategoryInDto;
 import foiegras.ygyg.post.application.dto.userpost.in.GetUserPostListInDto;
-import foiegras.ygyg.post.application.dto.userpost.out.GetUserPostListOutDto;
-import foiegras.ygyg.post.application.dto.userpost.out.PageInfoDto;
-import foiegras.ygyg.post.application.dto.userpost.out.UserPostItemDto;
+import foiegras.ygyg.post.application.dto.userpost.out.*;
 import foiegras.ygyg.post.infrastructure.entity.ItemImageUrlEntity;
 import foiegras.ygyg.post.infrastructure.entity.PostEntity;
 import foiegras.ygyg.post.infrastructure.entity.SeasoningCategoryEntity;
@@ -58,6 +57,7 @@ public class UserPostService {
 	 * 5. 작성자 UUID로 진행중인 소분글 조회
 	 * 6. 소분글 리스트 조회
 	 * 7. 카테고리로 소분글 리스트 조회
+	 * 8. 타입별 내 소분글 리스트 조회
 	 */
 
 	// 1. id로 UserPost 조회
@@ -170,6 +170,18 @@ public class UserPostService {
 			.maxEngageCount(postEntity.getMaxEngageCount())
 			.currentEngageCount(postEntity.getCurrentEngageCount())
 			.imageUrl(imageUrl).build();
+	}
+
+
+	// 8. 타입별 내 소분글 리스트 조회
+	public GetUserPostListByCursorOutDto getMyPostListByType(GetMyPostListInDto inDto) {
+		UserPostListQueryDataByCursorOutDto queryData = userPostQueryDslRepository.findPostListByCursor(inDto);
+		return GetUserPostListByCursorOutDto.builder()
+			.content(queryData.getContent())
+			.hasNext(queryData.hasNext())
+			.pageable(queryData.getPageable())
+			.lastCursor(queryData.getLastCursor())
+			.build();
 	}
 
 }

--- a/src/main/java/foiegras/ygyg/post/infrastructure/querydsl/UserPostQueryDslRepository.java
+++ b/src/main/java/foiegras/ygyg/post/infrastructure/querydsl/UserPostQueryDslRepository.java
@@ -1,6 +1,8 @@
 package foiegras.ygyg.post.infrastructure.querydsl;
 
 
+import foiegras.ygyg.post.application.dto.userpost.in.GetMyPostListInDto;
+import foiegras.ygyg.post.application.dto.userpost.out.UserPostListQueryDataByCursorOutDto;
 import foiegras.ygyg.post.infrastructure.entity.UserPostEntity;
 
 import java.time.LocalDateTime;
@@ -10,6 +12,10 @@ import java.util.UUID;
 
 public interface UserPostQueryDslRepository {
 
+	// 유저 UUID로, 유저가 참여한 진행중인 소분글 조회
 	List<UserPostEntity> findNotFinishedUserPostByUserUuid(UUID writerUuid, LocalDateTime deletedAt);
+
+	// 유저 UUID로, 타입별 소분글 조회
+	UserPostListQueryDataByCursorOutDto findPostListByCursor(GetMyPostListInDto inDto);
 
 }

--- a/src/main/java/foiegras/ygyg/post/infrastructure/querydsl/UserPostQueryDslRepositoryImpl.java
+++ b/src/main/java/foiegras/ygyg/post/infrastructure/querydsl/UserPostQueryDslRepositoryImpl.java
@@ -1,12 +1,18 @@
 package foiegras.ygyg.post.infrastructure.querydsl;
 
 
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import foiegras.ygyg.post.infrastructure.entity.QParticipatingUsersEntity;
-import foiegras.ygyg.post.infrastructure.entity.QUserPostEntity;
-import foiegras.ygyg.post.infrastructure.entity.UserPostEntity;
+import foiegras.ygyg.global.common.querydsl.PostDomainBooleanExpression;
+import foiegras.ygyg.global.common.querydsl.QueryDslService;
+import foiegras.ygyg.post.application.dto.userpost.in.GetMyPostListInDto;
+import foiegras.ygyg.post.application.dto.userpost.out.UserPostItemDto;
+import foiegras.ygyg.post.application.dto.userpost.out.UserPostListQueryDataByCursorOutDto;
+import foiegras.ygyg.post.infrastructure.entity.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -19,16 +25,24 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class UserPostQueryDslRepositoryImpl implements UserPostQueryDslRepository {
 
-	// value
+	// query dsl value
 	private final static QUserPostEntity userPostEntity = QUserPostEntity.userPostEntity;
 	private final static QParticipatingUsersEntity participatingUsersEntity = QParticipatingUsersEntity.participatingUsersEntity;
+	private final static QPostEntity postEntity = QPostEntity.postEntity;
+	private final static QItemImageUrlEntity itemImageUrlEntity = QItemImageUrlEntity.itemImageUrlEntity;
+	// static value
+	private final static String ASC = "asc";
+	private final static String DESC = "desc";
 	// querydsl
 	private final JPAQueryFactory queryFactory;
+	private final PostDomainBooleanExpression booleanExpression;
+	private final QueryDslService queryDslService;
 
 
 	/**
 	 * UserPostQueryDslRepository
 	 * 1. 유저 UUID로, 유저가 참여한 진행중인 소분글 조회
+	 * 2. 유저 UUID로, 타입별 소분글 조회
 	 */
 
 	// 1. 유저 UUID로, 유저가 참여한 진행중인 소분글 조회
@@ -41,6 +55,44 @@ public class UserPostQueryDslRepositoryImpl implements UserPostQueryDslRepositor
 				userPostEntity.portioningDate.gt(deletedAt)
 			)
 			.fetch();
+	}
+
+
+	// 2. 유저 UUID로, 타입별 소분글 조회
+	@Override
+	public UserPostListQueryDataByCursorOutDto findPostListByCursor(GetMyPostListInDto inDto) {
+		Pageable pageable = inDto.getPageable();
+		// content 조회
+		List<UserPostItemDto> content =
+			queryFactory
+				.select(Projections.constructor(UserPostItemDto.class,
+					userPostEntity.id,
+					userPostEntity.postTitle,
+					itemImageUrlEntity.imageUrl,
+					userPostEntity.portioningDate,
+					postEntity.originalPrice,
+					postEntity.minEngageCount,
+					postEntity.maxEngageCount,
+					postEntity.currentEngageCount
+				))
+				.from(userPostEntity)
+				.join(postEntity).on(postEntity.id.eq(userPostEntity.postEntity.id))
+				.leftJoin(itemImageUrlEntity).on(itemImageUrlEntity.postEntity.id.eq(postEntity.id)).limit(1)
+				.leftJoin(participatingUsersEntity).on(participatingUsersEntity.userPostEntity.id.eq(userPostEntity.id))
+				.where(
+					booleanExpression.selectType(inDto.getType(), inDto.getUserUuid(), inDto.getCurrentTime()),
+					booleanExpression.getNextUserPost(inDto.getLastCursor(), inDto.getOrder()))
+				.orderBy(inDto.getOrder().equals(ASC) ? userPostEntity.id.asc() : userPostEntity.id.desc())
+				.limit(pageable.getPageSize() + 1) // 다음 페이지 여부 확인을 위해 +1개 조회
+				.fetch();
+		// 다음 페이지 여부 확인 & content에서 마지막 값 제거, result = {hasNext, content}
+		Pair<Boolean, List<UserPostItemDto>> result = queryDslService.getHasNext(pageable, content);
+		Boolean hasNext = result.getFirst();
+		List<UserPostItemDto> finalContent = result.getSecond();
+		// lastCursorId: 마지막 커서 아이디
+		Long lastCursorId = queryDslService.getLastCursor(finalContent);
+		// result = content, pageable, hasNext, lastCursorId
+		return new UserPostListQueryDataByCursorOutDto(finalContent, pageable, hasNext, lastCursorId);
 	}
 
 }


### PR DESCRIPTION
# Issue
- #10 

# 변경점 👍
- 내가 작성한 소분글, 내가 참여중인 소분글, 내가 참여한 소분이 완료된 소분글 조회를 type별로 조회하는 API 개발
- queryDsl에서 공통적으로 사용되는 부분을 컴포넌트 & 서비스 클래스로 묶어서 구현