### PR TITLE
fix: 내 소분글 조회에서 중복 데이터가 조회되는 버그 수정

### DIFF
--- a/src/main/java/foiegras/ygyg/post/infrastructure/querydsl/UserPostQueryDslRepositoryImpl.java
+++ b/src/main/java/foiegras/ygyg/post/infrastructure/querydsl/UserPostQueryDslRepositoryImpl.java
@@ -83,6 +83,7 @@ public class UserPostQueryDslRepositoryImpl implements UserPostQueryDslRepositor
 					booleanExpression.selectType(inDto.getType(), inDto.getUserUuid(), inDto.getCurrentTime()),
 					booleanExpression.getNextUserPost(inDto.getLastCursor(), inDto.getOrder()))
 				.orderBy(inDto.getOrder().equals(ASC) ? userPostEntity.id.asc() : userPostEntity.id.desc())
+				.distinct()
 				.limit(pageable.getPageSize() + 1) // 다음 페이지 여부 확인을 위해 +1개 조회
 				.fetch();
 		// 다음 페이지 여부 확인 & content에서 마지막 값 제거, result = {hasNext, content}


### PR DESCRIPTION
# Issue
- #10 

# 버그 해결 💊
- participatingUser가 leftJoin으로 조회되어서 중복 데이터가 생김
- 따라서 distinct()를 사용하여 중복데이터를 제거